### PR TITLE
fix: unable to add other apps after one fails

### DIFF
--- a/src/components/LoadingButton.vue
+++ b/src/components/LoadingButton.vue
@@ -3,6 +3,7 @@
     :class="['loading-button', { 'loading-button--loading': isLoading }]"
     :type="type"
     :size="size"
+    :disabled="disabled"
     :text="isLoading ? loadingText : text"
     :iconLeft="loadingPosition === 'left' && isLoading ? 'loading-circle-1' : iconLeft"
     :iconCenter="loadingPosition === 'center' && isLoading ? 'loading-circle-1' : iconCenter"

--- a/src/store/appType/channels/whatsapp_cloud/mutations.js
+++ b/src/store/appType/channels/whatsapp_cloud/mutations.js
@@ -1,6 +1,9 @@
 export default {
   DEBUG_TOKEN_REQUEST(state) {
     state.loadingDebugToken = true;
+    state.wabaId = null;
+    state.businessId = null;
+    state.errorDebugToken = null;
   },
   DEBUG_TOKEN_SUCCESS(state, data) {
     state.wabaId = data.waba_id;
@@ -14,6 +17,8 @@ export default {
 
   PHONE_NUMBERS_REQUEST(state) {
     state.loadingPhoneNumbers = true;
+    state.whatsAppPhoneNumbers = null;
+    state.errorPhoneNumbers = null;
   },
   PHONE_NUMBERS_SUCCESS(state, data) {
     state.whatsAppPhoneNumbers = data;
@@ -26,6 +31,8 @@ export default {
 
   CLOUD_CONFIGURE_REQUEST(state) {
     state.loadingWhatsAppCloudConfigure = true;
+    state.loadingWhatsAppCloudConfigure = null;
+    state.errorCloudConfigure = null;
   },
   CLOUD_CONFIGURE_SUCCESS(state) {
     state.loadingWhatsAppCloudConfigure = false;

--- a/src/store/appType/mutations.js
+++ b/src/store/appType/mutations.js
@@ -1,6 +1,7 @@
 export default {
   DELETE_APP_REQUEST(state) {
     state.loadingDeleteApp = true;
+    state.errorDeleteApp = null;
   },
   DELETE_APP_SUCCESS(state) {
     state.loadingDeleteApp = false;
@@ -12,6 +13,8 @@ export default {
 
   CREATE_APP_REQUEST(state) {
     state.loadingCreateApp = true;
+    state.errorCreateApp = null;
+    state.createAppResponse = null;
   },
   CREATE_APP_SUCCESS(state, data) {
     state.createAppResponse = data;

--- a/tests/unit/specs/components/app/__snapshots__/AppDetailsHeader.spec.js.snap
+++ b/tests/unit/specs/components/app/__snapshots__/AppDetailsHeader.spec.js.snap
@@ -8,7 +8,7 @@ exports[`AppDetailsHeader.vue should be rendered properly 1`] = `
     <div class="app-details-header__content__description">some specific text</div>
   </div>
   <div type="add" class="app-details-header__button">
-    <unnnicbutton-stub size="large" text="some specific text" type="secondary" iconcenter="add-1" class="loading-button"></unnnicbutton-stub>
+    <unnnicbutton-stub size="large" text="some specific text" type="secondary" iconcenter="add-1" disabled="true" class="loading-button"></unnnicbutton-stub>
     <!---->
     <!---->
   </div>


### PR DESCRIPTION
The error state was not being cleared before another request was made, making successful future requests trigger the error state.