### PR TITLE
Feat: WhatsApp Templates Vuex store

### DIFF
--- a/src/api/appType/whatsapp/index.js
+++ b/src/api/appType/whatsapp/index.js
@@ -2,6 +2,8 @@ import qs from 'query-string';
 import request from '@/api/request.js';
 
 const resource = '/api/v1/apptypes';
+const templatesResource = '/api/v1/apps';
+
 export default {
   fetchWppContactInfo(appCode, appUuid) {
     return request.$http.get(`${resource}/${appCode}/apps/${appUuid}/contact/`);
@@ -24,8 +26,26 @@ export default {
   deleteWppProfilePhoto(appCode, appUuid) {
     return request.$http.delete(`${resource}/${appCode}/apps/${appUuid}/profile/`);
   },
-  getWhatsAppTemplates(appCode, appUuid, params) {
+  getWhatsAppTemplates(appUuid, params) {
     const queryString = qs.stringify(params);
-    return request.$http.get(`${resource}/${appCode}/apps/${appUuid}/template/?${queryString}`);
+    return request.$http.get(`${templatesResource}/${appUuid}/templates/?${queryString}`);
+  },
+  fetchTemplateData(appUuid, templateUuid) {
+    return request.$http.get(`${templatesResource}/${appUuid}/templates/${templateUuid}/`);
+  },
+  fetchSelectLanguages(appUuid) {
+    return request.$http.get(`${templatesResource}/${appUuid}/templates/languages/`);
+  },
+  createTemplate(appUuid, data) {
+    return request.$http.post(`${templatesResource}/${appUuid}/templates/`, data);
+  },
+  deleteTemplateMessage(appUuid, templateUuid) {
+    return request.$http.delete(`${templatesResource}/${appUuid}/templates/${templateUuid}`);
+  },
+  createTemplateTranslation(appUuid, templateUuid, data) {
+    return request.$http.post(
+      `${templatesResource}/${appUuid}/templates/${templateUuid}/translations/`,
+      data,
+    );
   },
 };

--- a/src/store/appType/channels/whatsapp/actions.js
+++ b/src/store/appType/channels/whatsapp/actions.js
@@ -1,4 +1,5 @@
 import whatsApp from '@/api/appType/whatsapp';
+import { captureSentryException } from '@/utils/sentry';
 
 export default {
   resetWppFetchResults({ commit }) {
@@ -21,6 +22,7 @@ export default {
       const { data } = await whatsApp.getConversations(code, appUuid, params);
       commit('CONVERSATIONS_SUCCESS', data);
     } catch (err) {
+      captureSentryException(err);
       commit('CONVERSATIONS_ERROR', err);
     }
   },
@@ -30,6 +32,7 @@ export default {
       const { data } = await whatsApp.fetchWppProfile(code, appUuid);
       commit('FETCH_WHATSAPP_PROFILE_SUCCESS', data);
     } catch (err) {
+      captureSentryException(err);
       commit('FETCH_WHATSAPP_PROFILE_ERROR', err);
     }
   },
@@ -39,6 +42,7 @@ export default {
       const { data } = await whatsApp.updateWppProfile(code, appUuid, payload);
       commit('UPDATE_WHATSAPP_PROFILE_SUCCESS', data);
     } catch (err) {
+      captureSentryException(err);
       commit('UPDATE_WHATSAPP_PROFILE_ERROR', err);
     }
   },
@@ -48,16 +52,101 @@ export default {
       const { data } = await whatsApp.deleteWppProfilePhoto(code, appUuid);
       commit('DELETE_WHATSAPP_PROFILE_PHOTO_SUCCESS', data);
     } catch (err) {
+      captureSentryException(err);
       commit('DELETE_WHATSAPP_PROFILE_PHOTO_ERROR', err);
     }
   },
-  async getWhatsAppTemplates({ commit }, { code, appUuid, params }) {
+  async getWhatsAppTemplates({ commit }, { appUuid, params }) {
     commit('GET_WHATSAPP_TEMPLATES_REQUEST');
     try {
-      const { data } = await whatsApp.getWhatsAppTemplates(code, appUuid, params);
+      const { data } = await whatsApp.getWhatsAppTemplates(appUuid, params);
       commit('GET_WHATSAPP_TEMPLATES_SUCCESS', data);
     } catch (err) {
+      captureSentryException(err);
       commit('GET_WHATSAPP_TEMPLATES_ERROR', err);
+    }
+  },
+
+  updateTemplateForm({ commit }, { fieldName, fieldValue }) {
+    commit('UPDATE_TEMPLATE_FORM', { fieldName, fieldValue });
+  },
+  addNewTranslationForm({ commit }, { formName, formData }) {
+    commit('ADD_NEW_TRANSLATION_FORM', { formName, formData });
+  },
+  renameTemplateTranslationForm({ commit }, { currentName, newName }) {
+    commit('RENAME_TEMPLATE_TRANSLATION_FORM', { currentName, newName });
+    commit('SET_TEMPLATE_TRANSLATION_SELECTED_FORM', { formName: newName });
+  },
+  updateTemplateTranslationForm({ commit }, { formName, fieldName, fieldValue, preventRerender }) {
+    if (preventRerender) {
+      commit('UPDATE_TEMPLATE_TRANSLATION_FORM_STATIC', { formName, fieldName, fieldValue });
+      return;
+    }
+    commit('UPDATE_TEMPLATE_TRANSLATION_FORM', { formName, fieldName, fieldValue });
+  },
+  setTemplateTranslationSelectedForm({ commit }, { formName }) {
+    commit('SET_TEMPLATE_TRANSLATION_SELECTED_FORM', { formName });
+  },
+  clearAllTemplateFormData({ commit }) {
+    commit('CLEAR_ALL_TEMPLATE_FORM_DATA');
+  },
+
+  async fetchTemplateData({ commit }, { appUuid, templateUuid }) {
+    commit('FETCH_WHATSAPP_TEMPLATE_REQUEST');
+    try {
+      const { data } = await whatsApp.fetchTemplateData(appUuid, templateUuid);
+      commit('FETCH_WHATSAPP_TEMPLATE_SUCCESS', data);
+    } catch (err) {
+      captureSentryException(err);
+      commit('FETCH_WHATSAPP_TEMPLATE_ERROR', err);
+    }
+  },
+
+  async fetchSelectLanguages({ commit }, { appUuid }) {
+    commit('FETCH_WHATSAPP_TEMPLATE_SELECT_LANGUAGES_REQUEST');
+    try {
+      const { data } = await whatsApp.fetchSelectLanguages(appUuid);
+      const formattedData = [];
+      for (const language in data) {
+        formattedData.push({ value: language, text: data[language] });
+      }
+      commit('FETCH_WHATSAPP_TEMPLATE_SELECT_LANGUAGES_SUCCESS', formattedData);
+    } catch (err) {
+      captureSentryException(err);
+      commit('FETCH_WHATSAPP_TEMPLATE_SELECT_LANGUAGES_ERROR', err);
+    }
+  },
+
+  async createTemplate({ commit }, { appUuid, payload }) {
+    commit('CREATE_TEMPLATE_REQUEST');
+    try {
+      const { data } = await whatsApp.createTemplate(appUuid, payload);
+      commit('CREATE_TEMPLATE_SUCCESS', data);
+    } catch (err) {
+      captureSentryException(err);
+      commit('CREATE_TEMPLATE_ERROR', err);
+    }
+  },
+
+  async createTemplateTranslation({ commit }, { appUuid, templateUuid, payload }) {
+    commit('CREATE_TEMPLATE_TRANSLATION_REQUEST');
+    try {
+      const { data } = await whatsApp.createTemplateTranslation(appUuid, templateUuid, payload);
+      commit('CREATE_TEMPLATE_TRANSLATION_SUCCESS', data);
+    } catch (err) {
+      captureSentryException(err);
+      commit('CREATE_TEMPLATE_TRANSLATION_ERROR', err);
+    }
+  },
+
+  async deleteTemplateMessage({ commit }, { appUuid, templateUuid }) {
+    commit('DELETE_TEMPLATE_MESSAGE_REQUEST');
+    try {
+      const { data } = await whatsApp.deleteTemplateMessage(appUuid, templateUuid);
+      commit('DELETE_TEMPLATE_MESSAGE_SUCCESS', data);
+    } catch (err) {
+      captureSentryException(err);
+      commit('DELETE_TEMPLATE_MESSAGE_ERROR', err);
     }
   },
 };

--- a/src/store/appType/channels/whatsapp/getters.js
+++ b/src/store/appType/channels/whatsapp/getters.js
@@ -8,4 +8,7 @@ export default {
   loadingContactInfo(state) {
     return state.loadingContactInfo;
   },
+  templateTranslationCurrentForm(state) {
+    return state.templateTranslationForms[state.templateTranslationSelectedForm] || {};
+  },
 };

--- a/src/store/appType/channels/whatsapp/mutations.js
+++ b/src/store/appType/channels/whatsapp/mutations.js
@@ -77,4 +77,110 @@ export default {
     state.errorWhatsAppTemplates = data;
     state.loadingWhatsAppTemplates = false;
   },
+
+  UPDATE_TEMPLATE_FORM(state, { fieldName, fieldValue }) {
+    const updatedForm = state.templateForm;
+    updatedForm[fieldName] = fieldValue;
+    state.templateForm = { ...updatedForm };
+  },
+  ADD_NEW_TRANSLATION_FORM(state, { formName, formData = {} }) {
+    state.templateTranslationForms[formName] = formData;
+  },
+  RENAME_TEMPLATE_TRANSLATION_FORM(state, { currentName, newName }) {
+    state.templateTranslationForms[newName] = state.templateTranslationForms[currentName];
+    delete state.templateTranslationForms[currentName];
+  },
+  UPDATE_TEMPLATE_TRANSLATION_FORM(state, { formName, fieldName, fieldValue }) {
+    const updatedForms = state.templateTranslationForms;
+
+    if (Array.isArray(fieldValue)) {
+      updatedForms[formName][fieldName] = [...fieldValue];
+    } else if (typeof fieldValue === 'object' && fieldValue !== null) {
+      updatedForms[formName][fieldName] = { ...fieldValue };
+    } else {
+      updatedForms[formName][fieldName] = fieldValue;
+    }
+
+    state.templateTranslationForms = { ...updatedForms };
+  },
+  UPDATE_TEMPLATE_TRANSLATION_FORM_STATIC(state, { formName, fieldName, fieldValue }) {
+    state.templateTranslationForms[formName][fieldName] = fieldValue;
+  },
+  SET_TEMPLATE_TRANSLATION_SELECTED_FORM(state, { formName }) {
+    state.templateTranslationSelectedForm = formName;
+  },
+
+  CLEAR_ALL_TEMPLATE_FORM_DATA(state) {
+    state.templateForm = {};
+    state.templateTranslationForms = {};
+    state.templateTranslationSelectedForm = null;
+  },
+
+  FETCH_WHATSAPP_TEMPLATE_REQUEST(state) {
+    state.loadingFetchWhatsAppTemplate = true;
+    state.errorFetchWhatsAppTemplate = null;
+  },
+  FETCH_WHATSAPP_TEMPLATE_SUCCESS(state, data) {
+    state.whatsAppTemplate = data;
+    state.loadingFetchWhatsAppTemplate = false;
+  },
+  FETCH_WHATSAPP_TEMPLATE_ERROR(state, data) {
+    state.errorFetchWhatsAppTemplate = data;
+    state.loadingFetchWhatsAppTemplate = false;
+  },
+
+  FETCH_WHATSAPP_TEMPLATE_SELECT_LANGUAGES_REQUEST(state) {
+    state.loadingFetchWhatsAppTemplateSelectLanguages = true;
+    state.errorFetchWhatsAppTemplateSelectLanguages = null;
+  },
+  FETCH_WHATSAPP_TEMPLATE_SELECT_LANGUAGES_SUCCESS(state, data) {
+    state.whatsAppTemplateSelectLanguages = data;
+    state.loadingFetchWhatsAppTemplateSelectLanguages = false;
+  },
+  FETCH_WHATSAPP_TEMPLATE_SELECT_LANGUAGES_ERROR(state, data) {
+    state.errorFetchWhatsAppTemplateSelectLanguages = data;
+    state.loadingFetchWhatsAppTemplateSelectLanguages = false;
+  },
+
+  CREATE_TEMPLATE_REQUEST(state) {
+    state.loadingCreateTemplate = true;
+    state.createdTemplateData = null;
+    state.errorCreateTemplate = null;
+  },
+  CREATE_TEMPLATE_SUCCESS(state, data) {
+    state.createdTemplateData = data;
+    state.loadingCreateTemplate = false;
+  },
+  CREATE_TEMPLATE_ERROR(state, data) {
+    state.errorCreateTemplate = data;
+    state.loadingCreateTemplate = false;
+  },
+
+  CREATE_TEMPLATE_TRANSLATION_REQUEST(state) {
+    state.loadingCreateTemplateTranslation = true;
+    state.createdTemplateTranslationData = null;
+    state.errorCreateTemplateTranslation = null;
+  },
+  CREATE_TEMPLATE_TRANSLATION_SUCCESS(state, data) {
+    state.createdTemplateTranslationData = data;
+    state.loadingCreateTemplateTranslation = false;
+  },
+  CREATE_TEMPLATE_TRANSLATION_ERROR(state, data) {
+    state.errorCreateTemplateTranslation = data;
+    state.loadingCreateTemplateTranslation = false;
+  },
+
+  DELETE_TEMPLATE_MESSAGE_REQUEST(state) {
+    state.loadingDeleteTemplateMessage = true;
+    state.deletedTemplateMessageData = null;
+    state.errorDeleteTemplateMessage = null;
+  },
+  DELETE_TEMPLATE_MESSAGE_SUCCESS(state, data) {
+    state.deletedTemplateMessageData = data;
+    state.loadingDeleteTemplateMessage = false;
+  },
+  DELETE_TEMPLATE_MESSAGE_ERROR(state, data) {
+    state.errorDeleteTemplateMessage = data;
+    state.loadingDeleteTemplateMessage = false;
+  },
 };

--- a/src/store/appType/channels/whatsapp/state.js
+++ b/src/store/appType/channels/whatsapp/state.js
@@ -26,4 +26,27 @@ export default {
   whatsAppTemplates: null,
   loadingWhatsAppTemplates: false,
   errorWhatsAppTemplates: false,
+
+  templateForm: {
+    name: null,
+    category: null,
+  },
+  templateTranslationForms: {},
+  templateTranslationSelectedForm: null,
+
+  whatsAppTemplate: null,
+  loadingFetchWhatsAppTemplate: false,
+  errorFetchWhatsAppTemplate: false,
+
+  whatsAppTemplateSelectLanguages: null,
+  loadingFetchWhatsAppTemplateSelectLanguages: false,
+  errorFetchWhatsAppTemplateSelectLanguages: false,
+
+  createdTemplateData: null,
+  loadingCreateTemplate: false,
+  errorCreateTemplate: false,
+
+  createdTemplateTranslationData: null,
+  loadingCreateTemplateTranslation: false,
+  errorCreateTemplateTranslation: false,
 };

--- a/tests/unit/specs/store/appType/whatsapp/getters.spec.js
+++ b/tests/unit/specs/store/appType/whatsapp/getters.spec.js
@@ -33,4 +33,19 @@ describe('store/appType/whatsapp/getters.js', () => {
   it('should return state.loadingContactInfo', () => {
     expect(store.getters['WhatsApp/loadingContactInfo']).toEqual(state.loadingContactInfo);
   });
+
+  it('should return state.templateTranslationCurrentForm', () => {
+    state.templateTranslationForms[state.templateTranslationSelectedForm] = {
+      foo: 'bar',
+    };
+
+    expect(store.getters['WhatsApp/templateTranslationCurrentForm']).toEqual(
+      state.templateTranslationForms[state.templateTranslationSelectedForm],
+    );
+  });
+
+  it('should return state.templateTranslationCurrentForm default as empty object', () => {
+    state.templateTranslationForms[state.templateTranslationSelectedForm] = null;
+    expect(store.getters['WhatsApp/templateTranslationCurrentForm']).toEqual({});
+  });
 });


### PR DESCRIPTION
Store related to WhatsApp template form management and data fetch/update.

- New Actions
  - updateTemplateForm
  - addNewTranslationForm
  - renameTemplateTranslationForm
  - updateTemplateTranslationForm
  - setTemplateTranslationSelectedForm
  - clearAllTemplateFormData
  - fetchTemplateData
  - fetchSelectLanguages
  - createTemplate
  - createTemplateTranslation
  - deleteTemplateMessage

- New getter
  - templateTranslationCurrentForm