### PR TITLE
Fix: WeniWebChat saveConfig incorrect error

### DIFF
--- a/src/components/config/channels/WWC/Config.vue
+++ b/src/components/config/channels/WWC/Config.vue
@@ -153,6 +153,7 @@
               type="secondary"
               size="large"
               :text="$t('apps.config.save_changes')"
+              :loading="loadingSave"
               @click="saveConfig"
             ></unnnic-button>
           </div>
@@ -215,6 +216,7 @@
               type="secondary"
               size="large"
               :text="$t('apps.config.save_changes')"
+              :loading="loadingSave"
               @click="saveConfig"
             ></unnnic-button>
           </div>
@@ -348,7 +350,11 @@
     },
     computed: {
       ...mapState({
+        loadingUpdateAppConfig: (state) => state.appType.loadingUpdateAppConfig,
         errorUpdateAppConfig: (state) => state.appType.errorUpdateAppConfig,
+        currentApp: (state) => state.appType.currentApp,
+        loadingCurrentApp: (state) => state.appType.loadingCurrentApp,
+        errorCurrentApp: (state) => state.appType.errorCurrentApp,
       }),
       avatarFiles: {
         get() {
@@ -412,6 +418,9 @@
             ${this.avatarFile}|
             ${this.customCssFile}
             `;
+      },
+      loadingSave() {
+        return this.loadingUpdateAppConfig || this.loadingCurrentApp;
       },
     },
     methods: {
@@ -586,8 +595,13 @@
             throw new Error(this.errorUpdateAppConfig);
           }
 
-          const { data } = await this.getApp({ code: this.app.code, appUuid: this.app.uuid });
-          this.app.config = data.config;
+          await this.getApp({ code: this.app.code, appUuid: this.app.uuid });
+
+          if (this.errorCurrentApp) {
+            throw new Error(this.errorCurrentApp);
+          }
+
+          this.app.config = this.currentApp.config;
           this.$emit('setConfirmation', false);
           unnnicCallAlert({
             props: {

--- a/tests/unit/specs/components/config/channels/WWC/Config.spec.js
+++ b/tests/unit/specs/components/config/channels/WWC/Config.spec.js
@@ -38,14 +38,15 @@ describe('wwc/Config.vue', () => {
 
     actions = {
       updateAppConfig: jest.fn(),
-      getApp: jest.fn(() => {
-        return { data: singleApp };
-      }),
+      getApp: jest.fn(),
     };
 
     state = {
       appType: {
         errorUpdateAppConfig: false,
+        currentApp: singleApp,
+        loadingCurrentApp: false,
+        errorCurrentApp: false,
       },
     };
 
@@ -233,9 +234,17 @@ describe('wwc/Config.vue', () => {
       expect(actions.getApp).toHaveBeenCalledTimes(1);
     });
 
-    it('should call unnnicCallAlert on error', async () => {
+    it('should call unnnicCallAlert on errorUpdateAppConfig', async () => {
       spyOn(wrapper.vm, 'validConfig').and.returnValue(true);
       store.state.appType.errorUpdateAppConfig = true;
+      expect(mockUnnnicCallAlert).not.toHaveBeenCalled();
+      await wrapper.vm.saveConfig();
+      expect(mockUnnnicCallAlert).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call unnnicCallAlert on errorCurrentApp', async () => {
+      spyOn(wrapper.vm, 'validConfig').and.returnValue(true);
+      store.state.appType.errorCurrentApp = true;
       expect(mockUnnnicCallAlert).not.toHaveBeenCalled();
       await wrapper.vm.saveConfig();
       expect(mockUnnnicCallAlert).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
- Fixed misuse of `getApp` action