### PR TITLE
Fix: Find text-area element based on node name and not index

### DIFF
--- a/src/components/whatsAppTemplates/FormTabContentBody.vue
+++ b/src/components/whatsAppTemplates/FormTabContentBody.vue
@@ -61,7 +61,10 @@
           return;
         }
 
-        const textArea = this.$refs.bodyText.$el.children[0];
+        const textArea = Array.from(this.$refs.bodyText.$el.children).find(
+          (child) => child.nodeName === 'TEXTAREA',
+        );
+
         const before = textArea.value.substring(0, textArea.selectionStart);
         const selectionContent = textArea.value.substring(
           textArea.selectionStart,


### PR DESCRIPTION
- When some language extensions are utilized in the browser, the input component is changed and the `textarea` child index is different from zero. Now we search based on the `nodeName` in the children list, avoiding that issue.