### PR TITLE
Fix: Discovery page memory issue

### DIFF
--- a/src/components/AppGrid.vue
+++ b/src/components/AppGrid.vue
@@ -110,7 +110,6 @@
 <script>
   import { unnnicCallAlert } from '@weni/unnnic-system';
   import { mapActions, mapState } from 'vuex';
-  import throttle from 'lodash.throttle';
 
   import configModal from './config/ConfigModal.vue';
   import skeletonLoading from './loadings/AppGrid.vue';

--- a/src/components/AppGrid.vue
+++ b/src/components/AppGrid.vue
@@ -154,7 +154,7 @@
     },
     /* istanbul ignore next */
     mounted() {
-      window.addEventListener('resize', throttle(this.updateGridSize, 1000));
+      window.addEventListener('resize', this.updateGridSize);
     },
     /* istanbul ignore next */
     unmounted() {
@@ -318,10 +318,9 @@
       },
       /* istanbul ignore next */
       updateGridSize() {
-        const gridElement = this.$refs.appGrid;
-        if (gridElement) {
-          const gridWidth = gridElement.clientWidth;
-          const maxWidthItems = Math.floor((gridWidth + 16) / 272);
+        const gridWidth = this.$refs.appGrid?.clientWidth;
+        if (gridWidth) {
+          const maxWidthItems = Math.floor((gridWidth + 16) / 272) || 1;
 
           this.gridSize = maxWidthItems * 2;
         }


### PR DESCRIPTION
- When grid size was too small `maxWidthItems` became zero due to `Math.floor` and caused zero division errors in other methods causing memory issues in browser tab. 
- Removed lodash.throttle