### PR TITLE
fix: wpp tabs scroll on firefox and horizontal wrap

### DIFF
--- a/src/components/config/channels/whatsapp/Config.vue
+++ b/src/components/config/channels/whatsapp/Config.vue
@@ -242,7 +242,6 @@
 
       &__description {
         display: flex;
-        flex-wrap: wrap;
 
         margin-top: $unnnic-inline-sm;
         padding-bottom: $unnnic-spacing-stack-md;
@@ -265,6 +264,7 @@
       flex-direction: column;
       overflow: hidden;
       height: 100%;
+      max-height: calc(100vh - 170px);
 
       ::v-deep .tab-body {
         display: flex;
@@ -281,6 +281,7 @@
         .tab-content {
           overflow-y: hidden;
           overflow-x: auto;
+          scrollbar-width: thin;
         }
 
         .tab-head {

--- a/src/components/config/channels/whatsapp/components/tabs/AccountTab.vue
+++ b/src/components/config/channels/whatsapp/components/tabs/AccountTab.vue
@@ -267,6 +267,7 @@
             line-height: $unnnic-font-size-body-gt + $unnnic-line-height-md;
             color: $unnnic-color-neutral-cloudy;
             margin: auto 0;
+            word-wrap: anywhere;
           }
 
           &__edit {


### PR DESCRIPTION
- Set a maximum height for WhatsApp tabs to be able to use the scroll on firefox
- Set `word-wrap: anywhere` on account table fields to prevent horizontal scroll