### PR TITLE
Fix: Allow empty webhook url

### DIFF
--- a/src/components/config/channels/whatsapp/components/tabs/WebhookTab.vue
+++ b/src/components/config/channels/whatsapp/components/tabs/WebhookTab.vue
@@ -183,14 +183,6 @@
         return result;
       },
       async saveWebhookInfo() {
-        if (!this.webhookUrl.trim()) {
-          this.callModal({
-            type: 'Error',
-            text: this.$t('WhatsApp.config.error.empty_url'),
-          });
-          return;
-        }
-
         const urlInput = this.getUrlInputElement();
         if (!urlInput.checkValidity()) {
           this.callModal({

--- a/tests/unit/specs/components/config/channels/whatsapp/components/tabs/WebhookTab.spec.js
+++ b/tests/unit/specs/components/config/channels/whatsapp/components/tabs/WebhookTab.spec.js
@@ -155,8 +155,8 @@ describe('components/config/channels/whatsapp/components/tabs/WebhookTab.vue', (
     expect(mockUnnnicCallAlert).toMatchSnapshot();
   });
 
-  it('should call errorModal if url is empty', async () => {
-    const { wrapper, actions } = await mountComponent({ errorUpdateWebhookInfo: true });
+  it('should not call errorModal if url is empty', async () => {
+    const { wrapper, actions } = await mountComponent();
 
     const urlInput = wrapper.find('.webhook-info__content__url');
 
@@ -171,7 +171,7 @@ describe('components/config/channels/whatsapp/components/tabs/WebhookTab.vue', (
     saveButton.trigger('click');
     await wrapper.vm.$nextTick();
 
-    expect(actions.updateWppWebhookInfo).not.toHaveBeenCalled();
+    expect(actions.updateWppWebhookInfo).toHaveBeenCalled();
     expect(mockUnnnicCallAlert).toMatchSnapshot();
   });
 

--- a/tests/unit/specs/components/config/channels/whatsapp/components/tabs/__snapshots__/WebhookTab.spec.js.snap
+++ b/tests/unit/specs/components/config/channels/whatsapp/components/tabs/__snapshots__/WebhookTab.spec.js.snap
@@ -106,32 +106,6 @@ exports[`components/config/channels/whatsapp/components/tabs/WebhookTab.vue shou
 }
 `;
 
-exports[`components/config/channels/whatsapp/components/tabs/WebhookTab.vue should call errorModal if url is empty 1`] = `
-[MockFunction] {
-  "calls": Array [
-    Array [
-      Object {
-        "props": Object {
-          "closeText": "Close",
-          "icon": "alert-circle-1",
-          "position": "bottom-right",
-          "scheme": "feedback-red",
-          "text": "Provided Webhook URL cannot be empty",
-          "title": "Error",
-        },
-        "seconds": 6,
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "type": "return",
-      "value": undefined,
-    },
-  ],
-}
-`;
-
 exports[`components/config/channels/whatsapp/components/tabs/WebhookTab.vue should call errorModal if url is invalid 1`] = `
 [MockFunction] {
   "calls": Array [
@@ -195,4 +169,30 @@ Array [
     "value": "",
   },
 ]
+`;
+
+exports[`components/config/channels/whatsapp/components/tabs/WebhookTab.vue should not call errorModal if url is empty 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      Object {
+        "props": Object {
+          "closeText": "Close",
+          "icon": "check-circle-1-1",
+          "position": "bottom-right",
+          "scheme": "feedback-green",
+          "text": "Successfully updated Webhook configuration",
+          "title": "Success",
+        },
+        "seconds": 6,
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
 `;


### PR DESCRIPTION
- Allow empty webhook url to enable the user to not receive webhooks after the first configuration