### PR TITLE
Feat: Edit WhatsApp Templates

### DIFF
--- a/src/api/appType/whatsapp/index.js
+++ b/src/api/appType/whatsapp/index.js
@@ -48,6 +48,9 @@ export default {
       data,
     );
   },
+  updateTemplateTranslation(appUuid, templateUuid, data) {
+    return request.$http.patch(`${templatesResource}/${appUuid}/templates/${templateUuid}/`, data);
+  },
   updateWppWebhookInfo(appCode, appUuid, payload) {
     return request.$http.patch(`${resource}/${appCode}/apps/${appUuid}/update_webhook/`, payload);
   },

--- a/src/components/whatsAppTemplates/FormTabContent.vue
+++ b/src/components/whatsAppTemplates/FormTabContent.vue
@@ -52,24 +52,24 @@
 
     <FormTabContentHeader
       class="form-tab-content__header"
-      :disableInputs="disableInputs"
+      :disableInputs="disableContentInputs"
       @input-change="handleGenericInput"
     />
     <FormTabContentBody
       ref="contentBody"
       class="form-tab-content__body"
-      :disableInputs="disableInputs"
+      :disableInputs="disableContentInputs"
       @input-change="handleGenericInput"
       @manual-preview-update="$emit('manual-preview-update')"
     />
     <FormTabContentFooter
       class="form-tab-content__footer"
-      :disableInputs="disableInputs"
+      :disableInputs="disableContentInputs"
       @input-change="handleGenericInput"
     />
     <FormTabContentButtons
       class="form-tab-content__buttons"
-      :disableInputs="disableInputs"
+      :disableInputs="disableContentInputs"
       @input-change="handleGenericInput"
     />
 
@@ -87,7 +87,7 @@
         size="large"
         :loading="loadingSave"
         :text="$t('WhatsApp.templates.form_field.save_language')"
-        :disabled="!canSave"
+        :disabled="!canSave || disableContentInputs"
         @click="saveTemplate"
       />
     </div>
@@ -178,6 +178,13 @@
       disableInputs() {
         return !this.canEdit;
       },
+      disableContentInputs() {
+        return (
+          this.templateTranslationCurrentForm?.status !== 'REJECTED' &&
+          this.templateTranslationCurrentForm?.status !== 'APPROVED' &&
+          !this.canEdit
+        );
+      },
       currentLanguage() {
         return this.templateTranslationCurrentForm?.language;
       },
@@ -194,7 +201,7 @@
         return this.$t(`WhatsApp.templates.category_options.${categoryLabel}`);
       },
       canSave() {
-        return !this.disableInputs && !this.templateTranslationCurrentForm?.bodyHasError;
+        return !this.templateTranslationCurrentForm?.bodyHasError;
       },
     },
     methods: {

--- a/src/components/whatsAppTemplates/FormTabContentButtons.vue
+++ b/src/components/whatsAppTemplates/FormTabContentButtons.vue
@@ -173,7 +173,6 @@
               :disabled="disableInputs"
               :value="currentButtons[index].url"
               @input="handleActionInput($event, 'url', index)"
-              @keydown="formatUrlInput($event)"
               :maxlength="2000"
               @focus="handleUrlFocus"
               @blur="handleUrlBlur"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -432,7 +432,8 @@
         "invalid_fields": "There are invalid fields, please fix them and try again.",
         "start_or_end_with_variable": "The body text contains variable parameters at the beginning or end.",
         "too_many_variables": "This template contains too many variable parameters relative to the message length. You need to decrease the number of variable parameters or increase the message length.",
-        "incomplete_bracket_variable": "This template contains variable parameters with incorrect formatting. Variable parameters must be whole numbers with two sets of curly brackets (for example, {{1}}, {{2}})."
+        "incomplete_bracket_variable": "This template contains variable parameters with incorrect formatting. Variable parameters must be whole numbers with two sets of curly brackets (for example, {{1}}, {{2}}).",
+        "update_translation": "Could not update the template, please try again later."
       },
       "new_language": "New Language",
       "form_field": {
@@ -505,7 +506,8 @@
         "PENDING": "Pending"
       },
       "success": {
-        "create_translation": "Successfully created Template Translation"
+        "create_translation": "Successfully created Template Translation",
+        "update_translation": "Successfully updated Template Translation"
       }
     }
   },

--- a/src/locales/es_es.json
+++ b/src/locales/es_es.json
@@ -432,7 +432,8 @@
         "invalid_fields": "Hay campos inválidos, corríjalos y vuelva a intentarlo.",
         "start_or_end_with_variable": "El cuerpo del texto contiene parámetros variables al principio o al final. Debe cambiar este formato o agregar una muestra.",
         "too_many_variables": "Esta plantilla contiene demasiados parámetros variables en relación con la longitud del mensaje. Debe disminuir el número de parámetros variables o aumentar la longitud del mensaje.",
-        "incomplete_bracket_variable": "Esta plantilla contiene parámetros variables con formato incorrecto. Los parámetros variables deben ser números enteros con dos juegos de corchetes (por ejemplo, {{1}}, {{2}})."
+        "incomplete_bracket_variable": "Esta plantilla contiene parámetros variables con formato incorrecto. Los parámetros variables deben ser números enteros con dos juegos de corchetes (por ejemplo, {{1}}, {{2}}).",
+        "update_translation": "No se puede actualizar la plantilla. Por favor, inténtelo de nuevo más tarde."
       },
       "new_language": "Nuevo Idioma",
       "form_field": {
@@ -505,7 +506,8 @@
         "PENDING": "Pendiente"
       },
       "success": {
-        "create_translation": "Traducción de plantilla creada con éxito"
+        "create_translation": "Traducción de plantilla creada con éxito",
+        "update_translation": "Traducción de plantilla actualizada con éxito"
       }
     }
   },

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -432,7 +432,8 @@
         "invalid_fields": "Existem campos inválidos, corrija-os e tente novamente.",
         "start_or_end_with_variable": "O corpo do texto contém parâmetros variáveis ​​no início ou no final.",
         "too_many_variables": "Este modelo contém muitos parâmetros variáveis ​​relativos ao comprimento da mensagem. Você precisa diminuir o número de parâmetros variáveis ​​ou aumentar o tamanho da mensagem.",
-        "incomplete_bracket_variable": "Este modelo contém parâmetros variáveis ​​com formatação incorreta. Os parâmetros variáveis ​​devem ser números inteiros com dois conjuntos de chaves (por exemplo, {{1}}, {{2}})."
+        "incomplete_bracket_variable": "Este modelo contém parâmetros variáveis ​​com formatação incorreta. Os parâmetros variáveis ​​devem ser números inteiros com dois conjuntos de chaves (por exemplo, {{1}}, {{2}}).",
+        "update_translation": "Não foi possível atualizar o template. Por favor tente novamente mais tarde."
       },
       "new_language": "Nova linguagem",
       "form_field": {
@@ -505,7 +506,8 @@
         "PENDING": "Pendente"
       },
       "success": {
-        "create_translation": "Tradução de template criada com sucesso"
+        "create_translation": "Tradução de template criada com sucesso",
+        "update_translation": "Tradução de template atualizada com sucesso"
       }
     }
   },

--- a/src/store/appType/channels/whatsapp/actions.js
+++ b/src/store/appType/channels/whatsapp/actions.js
@@ -87,6 +87,10 @@ export default {
     commit('CLEAR_ALL_TEMPLATE_FORM_DATA');
   },
 
+  clearTemplateData({ commit }) {
+    commit('CLEAR_TEMPLATE_DATA');
+  },
+
   async fetchTemplateData({ commit }, { appUuid, templateUuid }) {
     commit('FETCH_WHATSAPP_TEMPLATE_REQUEST');
     try {
@@ -132,6 +136,17 @@ export default {
     } catch (err) {
       captureSentryException(err);
       commit('CREATE_TEMPLATE_TRANSLATION_ERROR', err);
+    }
+  },
+
+  async updateTemplateTranslation({ commit }, { appUuid, templateUuid, payload }) {
+    commit('UPDATE_TEMPLATE_TRANSLATION_REQUEST');
+    try {
+      const { data } = await whatsApp.updateTemplateTranslation(appUuid, templateUuid, payload);
+      commit('UPDATE_TEMPLATE_TRANSLATION_SUCCESS', data);
+    } catch (err) {
+      captureSentryException(err);
+      commit('UPDATE_TEMPLATE_TRANSLATION_ERROR', err);
     }
   },
 

--- a/src/store/appType/channels/whatsapp/mutations.js
+++ b/src/store/appType/channels/whatsapp/mutations.js
@@ -113,6 +113,11 @@ export default {
     state.templateTranslationSelectedForm = null;
   },
 
+  CLEAR_TEMPLATE_DATA(state) {
+    state.whatsAppTemplate = null;
+    state.errorFetchWhatsAppTemplate = null;
+  },
+
   FETCH_WHATSAPP_TEMPLATE_REQUEST(state) {
     state.loadingFetchWhatsAppTemplate = true;
     state.errorFetchWhatsAppTemplate = null;
@@ -165,6 +170,20 @@ export default {
   CREATE_TEMPLATE_TRANSLATION_ERROR(state, data) {
     state.errorCreateTemplateTranslation = data;
     state.loadingCreateTemplateTranslation = false;
+  },
+
+  UPDATE_TEMPLATE_TRANSLATION_REQUEST(state) {
+    state.loadingUpdateTemplateTranslation = true;
+    state.updatedTemplateTranslationData = null;
+    state.errorUpdateTemplateTranslation = null;
+  },
+  UPDATE_TEMPLATE_TRANSLATION_SUCCESS(state, data) {
+    state.updatedTemplateTranslationData = data;
+    state.loadingUpdateTemplateTranslation = false;
+  },
+  UPDATE_TEMPLATE_TRANSLATION_ERROR(state, data) {
+    state.errorUpdateTemplateTranslation = data;
+    state.loadingUpdateTemplateTranslation = false;
   },
 
   DELETE_TEMPLATE_MESSAGE_REQUEST(state) {

--- a/src/store/appType/channels/whatsapp/state.js
+++ b/src/store/appType/channels/whatsapp/state.js
@@ -50,6 +50,10 @@ export default {
   loadingCreateTemplateTranslation: false,
   errorCreateTemplateTranslation: false,
 
+  updatedTemplateTranslationData: null,
+  loadingUpdateTemplateTranslation: false,
+  errorUpdateTemplateTranslation: false,
+
   loadingUpdateWebhookInfo: false,
   errorUpdateWebhookInfo: null,
   updateWebhookInfoData: null,

--- a/tests/unit/specs/components/whatsAppTemplates/FormTabContent.spec.js
+++ b/tests/unit/specs/components/whatsAppTemplates/FormTabContent.spec.js
@@ -32,6 +32,7 @@ const mountComponent = ({
   availableLanguages = [],
   templateResults = [],
   canEdit = true,
+  bodyHasError = false,
 } = {}) => {
   if (!availableLanguages.length) {
     availableLanguages = [
@@ -48,7 +49,7 @@ const mountComponent = ({
 
   const getters = {
     templateTranslationCurrentForm: jest.fn(() => {
-      return { language };
+      return { language, bodyHasError };
     }),
   };
 
@@ -439,7 +440,7 @@ describe('components/whatsAppTemplates/FormTabContent.vue', () => {
     });
 
     it('should not emit save-changes if cannot save', async () => {
-      const { wrapper } = mountComponent({ canEdit: false });
+      const { wrapper } = mountComponent({ bodyHasError: true });
 
       expect(wrapper.emitted('save-changes')).toBeFalsy();
 

--- a/tests/unit/specs/store/appType/whatsapp/actions.spec.js
+++ b/tests/unit/specs/store/appType/whatsapp/actions.spec.js
@@ -13,6 +13,7 @@ jest.mock('@/api/appType/whatsapp', () => {
     createTemplateTranslation: jest.fn(),
     deleteTemplateMessage: jest.fn(),
     updateWppWebhookInfo: jest.fn(),
+    updateTemplateTranslation: jest.fn(),
   };
 });
 import WhatsAppApi from '@/api/appType/whatsapp';
@@ -773,6 +774,60 @@ describe('store/appType/whatsapp/actions.js', () => {
     });
   });
 
+  describe('updateTemplateTranslation()', () => {
+    const data = {
+      appUuid: '123',
+      templateUuid: '456',
+      payload: {},
+    };
+
+    const mockedResult = {};
+
+    beforeEach(() => {
+      jest.resetAllMocks();
+
+      WhatsAppApi.updateTemplateTranslation.mockImplementation(() => {
+        return Promise.resolve({ data: mockedResult });
+      });
+    });
+
+    it('should call updateTemplateTranslation from API', async () => {
+      expect(WhatsAppApi.updateTemplateTranslation).not.toHaveBeenCalled();
+      await store.dispatch('WhatsApp/updateTemplateTranslation', data);
+      expect(WhatsAppApi.updateTemplateTranslation).toHaveBeenCalledTimes(1);
+      expect(WhatsAppApi.updateTemplateTranslation).toHaveBeenCalledWith(
+        data.appUuid,
+        data.templateUuid,
+        data.payload,
+      );
+    });
+
+    it('should set updatedTemplateTranslationData as result data', async () => {
+      store.state.WhatsApp.updatedTemplateTranslationData = null;
+      expect(store.state.WhatsApp.updatedTemplateTranslationData).not.toEqual(mockedResult);
+      await store.dispatch('WhatsApp/updateTemplateTranslation', data);
+      expect(store.state.WhatsApp.updatedTemplateTranslationData).toEqual(mockedResult);
+    });
+
+    it('should set loadingUpdateTemplateTranslation to false', async () => {
+      store.state.WhatsApp.loadingUpdateTemplateTranslation = true;
+      expect(store.state.WhatsApp.loadingUpdateTemplateTranslation).toBe(true);
+      await store.dispatch('WhatsApp/updateTemplateTranslation', data);
+      expect(store.state.WhatsApp.loadingUpdateTemplateTranslation).toBe(false);
+    });
+
+    it('should set errorUpdateTemplateTranslation as result data', async () => {
+      const error = { error: 'failed' };
+      WhatsAppApi.updateTemplateTranslation.mockImplementation(() => {
+        return Promise.reject(error);
+      });
+      store.state.WhatsApp.errorUpdateTemplateTranslation = {};
+      expect(store.state.WhatsApp.errorUpdateTemplateTranslation).not.toEqual(error);
+      await store.dispatch('WhatsApp/updateTemplateTranslation', data);
+      expect(store.state.WhatsApp.errorUpdateTemplateTranslation).toEqual(error);
+    });
+  });
+
   describe('deleteTemplateMessage()', () => {
     const data = {
       appUuid: '123',
@@ -878,6 +933,18 @@ describe('store/appType/whatsapp/actions.js', () => {
       expect(store.state.WhatsApp.errorUpdateWebhookInfo).not.toEqual(error);
       await store.dispatch('WhatsApp/updateWppWebhookInfo', data);
       expect(store.state.WhatsApp.errorUpdateWebhookInfo).toEqual(error);
+    });
+  });
+
+  describe('clearTemplateData()', () => {
+    it('should clear template data', () => {
+      store.state.WhatsApp.whatsAppTemplate = { foo: 'bar' };
+      store.state.WhatsApp.errorFetchWhatsAppTemplate = true;
+      expect(store.state.WhatsApp.whatsAppTemplate).toEqual({ foo: 'bar' });
+      expect(store.state.WhatsApp.errorFetchWhatsAppTemplate).toEqual(true);
+      store.dispatch('WhatsApp/clearTemplateData');
+      expect(store.state.WhatsApp.whatsAppTemplate).toEqual(null);
+      expect(store.state.WhatsApp.errorFetchWhatsAppTemplate).toEqual(null);
     });
   });
 });


### PR DESCRIPTION
- Added option to edit WhatsApp templates, using the message_template_id from the translations as the identifier
- Only allow edit behavior when the template is APPROVED or REJECTED