### PR TITLE
Fix: WhatsApp Templates date picker

### DIFF
--- a/src/components/whatsAppTemplates/Table.vue
+++ b/src/components/whatsAppTemplates/Table.vue
@@ -20,6 +20,8 @@
             v-show="showDateFilter"
             size="large"
             :days="['D', 'S', 'T', 'Q', 'Q', 'S', 'S']"
+            :months="months"
+            :options="options"
             @submit="handleDateFilter"
             :value="datePickerDates"
             :clearLabel="$t('WhatsApp.templates.table.filters.date.clear')"
@@ -264,6 +266,28 @@
             text: this.$t('WhatsApp.templates.table.headers.actions'),
             width: '55px',
           },
+        ],
+        months: [
+          this.$t('date.months.january'),
+          this.$t('date.months.february'),
+          this.$t('date.months.march'),
+          this.$t('date.months.april'),
+          this.$t('date.months.may'),
+          this.$t('date.months.june'),
+          this.$t('date.months.july'),
+          this.$t('date.months.august'),
+          this.$t('date.months.september'),
+          this.$t('date.months.october'),
+          this.$t('date.months.november'),
+          this.$t('date.months.december'),
+        ],
+        options: [
+          { name: this.$t('date.options.seven_days'), id: 'last-7-days' },
+          { name: this.$t('date.options.fourteen_days'), id: 'last-14-days' },
+          { name: this.$t('date.options.thirty_days'), id: 'last-30-days' },
+          { name: this.$t('date.options.twelve_months'), id: 'last-12-months' },
+          { name: this.$t('date.options.current_month'), id: 'current-month' },
+          { name: this.$t('date.options.personalize'), id: 'custom' },
         ],
       };
     },

--- a/src/components/whatsAppTemplates/Table.vue
+++ b/src/components/whatsAppTemplates/Table.vue
@@ -18,10 +18,12 @@
           <unnnic-date-picker
             class="whatsapp-templates-table__filters__date__dropdown-date__picker"
             v-show="showDateFilter"
-            size="small"
+            size="large"
             :days="['D', 'S', 'T', 'Q', 'Q', 'S', 'S']"
-            @change="handleDateFilter"
+            @submit="handleDateFilter"
             :value="datePickerDates"
+            :clearLabel="$t('WhatsApp.templates.table.filters.date.clear')"
+            :actionLabel="$t('WhatsApp.templates.table.filters.date.filter')"
           />
         </div>
       </div>
@@ -399,6 +401,8 @@
       handleDateFilter: debounce(async function (event) {
         this.startDate = event.startDate;
         this.endDate = event.endDate;
+
+        this.showDateFilter = false;
       }, 750),
       handleNameSort(sortDirection) {
         this.nameSortDirection = sortDirection;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -430,7 +430,9 @@
         "new_template": "New Template",
         "filters": {
           "date": {
-            "label": "Date"
+            "label": "Date",
+            "clear": "Clear",
+            "filter": "Filter"
           },
           "search": "Search",
           "category": "Category"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -19,6 +19,30 @@
     "empty_input": "Required fields cannot be empty.",
     "required_message": "This field is required."
   },
+  "date": {
+    "months": {
+      "january": "January",
+      "february": "February",
+      "march": "March",
+      "april": "April",
+      "june": "June",
+      "may": "May",
+      "july": "July",
+      "august": "August",
+      "september": "September",
+      "october": "October",
+      "november": "November",
+      "december": "December"
+    },
+    "options": {
+      "seven_days": "Last 7 days",
+      "fourteen_days": "Last 14 days",
+      "thirty_days": "Last 30 days",
+      "twelve_months": "Last 12 months",
+      "current_month": "Current month",
+      "personalize": "Personalize"
+    }
+  },
   "apps": {
     "nav": {
       "discovery": "Discovery",

--- a/src/locales/es_es.json
+++ b/src/locales/es_es.json
@@ -430,7 +430,9 @@
         "new_template": "Nueva Plantilla",
         "filters": {
           "date": {
-            "label": "Fecha"
+            "label": "Fecha",
+            "clear": "Limpiar",
+            "filter": "Filtrar"
           },
           "search": "Buscar",
           "category": "Categoría"

--- a/src/locales/es_es.json
+++ b/src/locales/es_es.json
@@ -19,6 +19,30 @@
     "empty_input": "Los campos obligatorios no pueden estar vacíos.",
     "required_message": "Este campo es necesario."
   },
+  "date": {
+    "months": {
+      "january": "Enero",
+      "february": "Febrero",
+      "march": "Marzo",
+      "april": "Abril",
+      "may": "Mayo",
+      "june": "Junio",
+      "july": "Julio",
+      "august": "Agosto",
+      "september": "Septiembre",
+      "october": "Octubre",
+      "november": "Noviembre",
+      "december": "Diciembre"
+    },
+    "options": {
+      "seven_days": "Últimos 7 días",
+      "fourteen_days": "Últimos 14 días",
+      "thirty_days": "Últimos 30 días",
+      "twelve_months": "Últimos 12 meses",
+      "current_month": "Mes actual",
+      "personalize": "Personalizar"
+    }
+  },
   "apps": {
     "nav": {
       "discovery": "Descubrimiento",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -19,6 +19,30 @@
     "empty_input": "Campos obrigatórios não podem estar vazios.",
     "required_message": "Este campo é obrigatório."
   },
+  "date": {
+    "months": {
+      "january": "Janeiro",
+      "february": "Fevereiro",
+      "march": "Março",
+      "april": "Abril",
+      "may": "Maio",
+      "june": "Junho",
+      "july": "Julho",
+      "august": "Agosto",
+      "september": "Setembro",
+      "october": "Outubro",
+      "november": "Novembro",
+      "december": "Dezembro"
+    },
+    "options": {
+      "seven_days": "Últimos 7 dias",
+      "fourteen_days": "Últimos 14 dias",
+      "thirty_days": "Últimos 30 dias",
+      "twelve_months": "Últimos 12 meses",
+      "current_month": "Mês Atual",
+      "personalize": "Personalizar"
+    }
+  },
   "apps": {
     "nav": {
       "discovery": "Descoberta",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -430,7 +430,9 @@
         "new_template": "Novo Template",
         "filters": {
           "date": {
-            "label": "Data"
+            "label": "Data",
+            "clear": "Limpar",
+            "filter": "Filtrar"
           },
           "search": "Buscar",
           "category": "Categoria"

--- a/tests/unit/specs/components/whatsAppTemplates/Table.spec.js
+++ b/tests/unit/specs/components/whatsAppTemplates/Table.spec.js
@@ -406,7 +406,7 @@ describe('components/whatsAppTemplates/Table.vue', () => {
       expect(wrapper.vm.startDate).toBe(null);
       expect(wrapper.vm.endDate).toBe(null);
 
-      dateInput.vm.$emit('change', { startDate: '01-01-2023', endDate: '31-01-2023' });
+      dateInput.vm.$emit('submit', { startDate: '01-01-2023', endDate: '31-01-2023' });
 
       await wrapper.vm.$nextTick();
       expect(wrapper.vm.startDate).toBe('01-01-2023');

--- a/tests/unit/specs/components/whatsAppTemplates/__snapshots__/Table.spec.js.snap
+++ b/tests/unit/specs/components/whatsAppTemplates/__snapshots__/Table.spec.js.snap
@@ -19,14 +19,14 @@ exports[`components/whatsAppTemplates/Table.vue should be rendered properly 1`] 
       <div class="whatsapp-templates-table__filters__date__dropdown-date">
         <div data-v-2bc87923="" class="unnnic-date-picker whatsapp-templates-table__filters__date__dropdown-date__picker" value="[object Object]" style="display: none;">
           <div data-v-2bc87923="" class="month-container">
-            <div data-v-2bc87923="" class="header header--small"><button data-v-00f478da="" data-v-2bc87923="" class="button-space unnnic-button unnnic-button--size-small unnnic-button--terciary unnnic-button-scheme-- unnnic-button--icon-on-center" style="grid-area: left-button;">
+            <div data-v-2bc87923="" class="header header--large"><button data-v-00f478da="" data-v-2bc87923="" class="button-space unnnic-button unnnic-button--size-small unnnic-button--secondary unnnic-button-scheme-- unnnic-button--icon-on-center" style="grid-area: left-button;">
                 <!---->
-                <!----><span data-v-12da8e0b="" data-v-00f478da="" class="unnnic-icon unnnic-icon__size--sm"><svg viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M26.8368 35.0005C26.5868 35.0005 26.3506 34.903 26.1743 34.7255L12.7743 21.3255C12.4206 20.9717 12.2256 20.5017 12.2256 20.0017C12.2256 19.5017 12.4193 19.0305 12.7731 18.6767L26.1743 5.27549C26.3506 5.09799 26.5868 5.00049 26.8368 5.00049C27.0868 5.00049 27.3231 5.09799 27.4993 5.27549C27.6768 5.45174 27.7743 5.68799 27.7743 5.93799C27.7743 6.18799 27.6768 6.42424 27.4993 6.60049L14.0993 20.0005L27.4993 33.4005C27.6768 33.578 27.7743 33.813 27.7743 34.063C27.7743 34.313 27.6768 34.5492 27.4993 34.7255C27.3218 34.9017 27.0868 35.0005 26.8368 35.0005Z" fill="#3B414D" class="primary"></path></svg></span><span data-v-00f478da="" class="unnnic-button__label">  </span>
+                <!----><span data-v-12da8e0b="" data-v-00f478da="" class="unnnic-icon unnnic-icon__size--sm unnnic-icon-scheme--neutral-dark"><svg viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M26.8368 35.0005C26.5868 35.0005 26.3506 34.903 26.1743 34.7255L12.7743 21.3255C12.4206 20.9717 12.2256 20.5017 12.2256 20.0017C12.2256 19.5017 12.4193 19.0305 12.7731 18.6767L26.1743 5.27549C26.3506 5.09799 26.5868 5.00049 26.8368 5.00049C27.0868 5.00049 27.3231 5.09799 27.4993 5.27549C27.6768 5.45174 27.7743 5.68799 27.7743 5.93799C27.7743 6.18799 27.6768 6.42424 27.4993 6.60049L14.0993 20.0005L27.4993 33.4005C27.6768 33.578 27.7743 33.813 27.7743 34.063C27.7743 34.313 27.6768 34.5492 27.4993 34.7255C27.3218 34.9017 27.0868 35.0005 26.8368 35.0005Z" fill="#3B414D" class="primary"></path></svg></span><span data-v-00f478da="" class="unnnic-button__label">  </span>
                 <!---->
               </button>
-              <div data-v-2bc87923="" class="label label--small"> Agosto 2018 </div>
+              <div data-v-2bc87923="" class="label label--large"> Agosto 2018 </div>
             </div>
-            <div data-v-2bc87923="" class="days days--small">
+            <div data-v-2bc87923="" class="days days--large">
               <div data-v-2bc87923="" class="name">D</div>
               <div data-v-2bc87923="" class="name">S</div>
               <div data-v-2bc87923="" class="name">T</div>
@@ -80,14 +80,14 @@ exports[`components/whatsAppTemplates/Table.vue should be rendered properly 1`] 
           </div>
           <div data-v-2bc87923="" class="divider"></div>
           <div data-v-2bc87923="" class="month-container">
-            <div data-v-2bc87923="" class="header header--small"><button data-v-00f478da="" data-v-2bc87923="" class="button-space unnnic-button unnnic-button--size-small unnnic-button--terciary unnnic-button-scheme-- unnnic-button--icon-on-center" style="grid-area: right-button;">
+            <div data-v-2bc87923="" class="header header--large"><button data-v-00f478da="" data-v-2bc87923="" class="button-space unnnic-button unnnic-button--size-small unnnic-button--secondary unnnic-button-scheme-- unnnic-button--icon-on-center" style="grid-area: right-button;">
                 <!---->
-                <!----><span data-v-12da8e0b="" data-v-00f478da="" class="unnnic-icon unnnic-icon__size--sm"><svg viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M13.1635 35.0005C12.9135 35.0005 12.6772 34.903 12.501 34.7255C12.136 34.3605 12.136 33.7655 12.501 33.3992L25.901 20.0005L12.501 6.60049C12.3235 6.42424 12.226 6.18799 12.226 5.93799C12.226 5.68799 12.3235 5.45174 12.501 5.27549C12.6772 5.09799 12.9135 5.00049 13.1635 5.00049C13.4135 5.00049 13.6497 5.09799 13.826 5.27549L27.226 18.6755C27.956 19.4055 27.9572 20.5942 27.2272 21.3242L13.826 34.7255C13.6497 34.903 13.4135 35.0005 13.1635 35.0005Z" fill="#3B414D" class="primary"></path></svg></span><span data-v-00f478da="" class="unnnic-button__label">  </span>
+                <!----><span data-v-12da8e0b="" data-v-00f478da="" class="unnnic-icon unnnic-icon__size--sm unnnic-icon-scheme--neutral-dark"><svg viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M13.1635 35.0005C12.9135 35.0005 12.6772 34.903 12.501 34.7255C12.136 34.3605 12.136 33.7655 12.501 33.3992L25.901 20.0005L12.501 6.60049C12.3235 6.42424 12.226 6.18799 12.226 5.93799C12.226 5.68799 12.3235 5.45174 12.501 5.27549C12.6772 5.09799 12.9135 5.00049 13.1635 5.00049C13.4135 5.00049 13.6497 5.09799 13.826 5.27549L27.226 18.6755C27.956 19.4055 27.9572 20.5942 27.2272 21.3242L13.826 34.7255C13.6497 34.903 13.4135 35.0005 13.1635 35.0005Z" fill="#3B414D" class="primary"></path></svg></span><span data-v-00f478da="" class="unnnic-button__label">  </span>
                 <!---->
               </button>
-              <div data-v-2bc87923="" class="label label--small"> Setembro 2018 </div>
+              <div data-v-2bc87923="" class="label label--large"> Setembro 2018 </div>
             </div>
-            <div data-v-2bc87923="" class="days days--small">
+            <div data-v-2bc87923="" class="days days--large">
               <div data-v-2bc87923="" class="name">D</div>
               <div data-v-2bc87923="" class="name">S</div>
               <div data-v-2bc87923="" class="name">T</div>
@@ -140,7 +140,27 @@ exports[`components/whatsAppTemplates/Table.vue should be rendered properly 1`] 
             </div>
           </div>
           <div data-v-2bc87923="" class="divider"></div>
-          <!---->
+          <div data-v-2bc87923="" class="options-container">
+            <div data-v-2bc87923="" class="options">
+              <div data-v-2bc87923="" class="option"> Últimos 7 dias </div>
+              <div data-v-2bc87923="" class="option"> Últimos 14 dias </div>
+              <div data-v-2bc87923="" class="option"> Últimos 30 dias </div>
+              <div data-v-2bc87923="" class="option"> Últimos 12 meses </div>
+              <div data-v-2bc87923="" class="option"> Mês Atual </div>
+              <div data-v-2bc87923="" class="option"> Personalizar </div>
+            </div>
+            <div data-v-2bc87923="" class="actions"><button data-v-00f478da="" data-v-2bc87923="" class="unnnic-button unnnic-button--size-small unnnic-button--terciary unnnic-button-scheme--">
+                <!---->
+                <!---->
+                <!----><span data-v-00f478da="" class="unnnic-button__label"> some specific text </span>
+                <!---->
+              </button><button data-v-00f478da="" data-v-2bc87923="" class="unnnic-button unnnic-button--size-small unnnic-button--secondary unnnic-button-scheme--">
+                <!---->
+                <!---->
+                <!----><span data-v-00f478da="" class="unnnic-button__label"> some specific text </span>
+                <!---->
+              </button></div>
+          </div>
         </div>
       </div>
     </div>

--- a/tests/unit/specs/components/whatsAppTemplates/__snapshots__/Table.spec.js.snap
+++ b/tests/unit/specs/components/whatsAppTemplates/__snapshots__/Table.spec.js.snap
@@ -24,7 +24,7 @@ exports[`components/whatsAppTemplates/Table.vue should be rendered properly 1`] 
                 <!----><span data-v-12da8e0b="" data-v-00f478da="" class="unnnic-icon unnnic-icon__size--sm unnnic-icon-scheme--neutral-dark"><svg viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M26.8368 35.0005C26.5868 35.0005 26.3506 34.903 26.1743 34.7255L12.7743 21.3255C12.4206 20.9717 12.2256 20.5017 12.2256 20.0017C12.2256 19.5017 12.4193 19.0305 12.7731 18.6767L26.1743 5.27549C26.3506 5.09799 26.5868 5.00049 26.8368 5.00049C27.0868 5.00049 27.3231 5.09799 27.4993 5.27549C27.6768 5.45174 27.7743 5.68799 27.7743 5.93799C27.7743 6.18799 27.6768 6.42424 27.4993 6.60049L14.0993 20.0005L27.4993 33.4005C27.6768 33.578 27.7743 33.813 27.7743 34.063C27.7743 34.313 27.6768 34.5492 27.4993 34.7255C27.3218 34.9017 27.0868 35.0005 26.8368 35.0005Z" fill="#3B414D" class="primary"></path></svg></span><span data-v-00f478da="" class="unnnic-button__label">  </span>
                 <!---->
               </button>
-              <div data-v-2bc87923="" class="label label--large"> Agosto 2018 </div>
+              <div data-v-2bc87923="" class="label label--large"> some specific text 2018 </div>
             </div>
             <div data-v-2bc87923="" class="days days--large">
               <div data-v-2bc87923="" class="name">D</div>
@@ -85,7 +85,7 @@ exports[`components/whatsAppTemplates/Table.vue should be rendered properly 1`] 
                 <!----><span data-v-12da8e0b="" data-v-00f478da="" class="unnnic-icon unnnic-icon__size--sm unnnic-icon-scheme--neutral-dark"><svg viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M13.1635 35.0005C12.9135 35.0005 12.6772 34.903 12.501 34.7255C12.136 34.3605 12.136 33.7655 12.501 33.3992L25.901 20.0005L12.501 6.60049C12.3235 6.42424 12.226 6.18799 12.226 5.93799C12.226 5.68799 12.3235 5.45174 12.501 5.27549C12.6772 5.09799 12.9135 5.00049 13.1635 5.00049C13.4135 5.00049 13.6497 5.09799 13.826 5.27549L27.226 18.6755C27.956 19.4055 27.9572 20.5942 27.2272 21.3242L13.826 34.7255C13.6497 34.903 13.4135 35.0005 13.1635 35.0005Z" fill="#3B414D" class="primary"></path></svg></span><span data-v-00f478da="" class="unnnic-button__label">  </span>
                 <!---->
               </button>
-              <div data-v-2bc87923="" class="label label--large"> Setembro 2018 </div>
+              <div data-v-2bc87923="" class="label label--large"> some specific text 2018 </div>
             </div>
             <div data-v-2bc87923="" class="days days--large">
               <div data-v-2bc87923="" class="name">D</div>
@@ -142,12 +142,12 @@ exports[`components/whatsAppTemplates/Table.vue should be rendered properly 1`] 
           <div data-v-2bc87923="" class="divider"></div>
           <div data-v-2bc87923="" class="options-container">
             <div data-v-2bc87923="" class="options">
-              <div data-v-2bc87923="" class="option"> Últimos 7 dias </div>
-              <div data-v-2bc87923="" class="option"> Últimos 14 dias </div>
-              <div data-v-2bc87923="" class="option"> Últimos 30 dias </div>
-              <div data-v-2bc87923="" class="option"> Últimos 12 meses </div>
-              <div data-v-2bc87923="" class="option"> Mês Atual </div>
-              <div data-v-2bc87923="" class="option"> Personalizar </div>
+              <div data-v-2bc87923="" class="option"> some specific text </div>
+              <div data-v-2bc87923="" class="option"> some specific text </div>
+              <div data-v-2bc87923="" class="option"> some specific text </div>
+              <div data-v-2bc87923="" class="option"> some specific text </div>
+              <div data-v-2bc87923="" class="option"> some specific text </div>
+              <div data-v-2bc87923="" class="option"> some specific text </div>
             </div>
             <div data-v-2bc87923="" class="actions"><button data-v-00f478da="" data-v-2bc87923="" class="unnnic-button unnnic-button--size-small unnnic-button--terciary unnnic-button-scheme--">
                 <!---->


### PR DESCRIPTION
- Use the larger datepicker instead of small one to be able to clear the dates