### PR TITLE
[FLOWS-228] Fix: ChatGPT modal height

### DIFF
--- a/src/components/config/external/chatgpt/Setup.vue
+++ b/src/components/config/external/chatgpt/Setup.vue
@@ -9,9 +9,6 @@
     :description="$t('ChatGPT.setup.description')"
   >
     <div slot="message" class="chatgpt-modal__content">
-      <!-- <span class="chatgpt-modal__content__title">{{ $t('ChatGPT.setup.title') }}</span>
-      <span class="chatgpt-modal__content__description">{{ $t('ChatGPT.setup.description') }}</span> -->
-
       <div class="chatgpt-modal__content__form">
         <unnnic-input
           class="chatgpt-modal__content__form__input__name"

--- a/src/components/config/external/chatgpt/Setup.vue
+++ b/src/components/config/external/chatgpt/Setup.vue
@@ -5,10 +5,12 @@
     @close="closePopUp"
     @click.stop
     :closeIcon="false"
+    :text="$t('ChatGPT.setup.title')"
+    :description="$t('ChatGPT.setup.description')"
   >
     <div slot="message" class="chatgpt-modal__content">
-      <span class="chatgpt-modal__content__title">{{ $t('ChatGPT.setup.title') }}</span>
-      <span class="chatgpt-modal__content__description">{{ $t('ChatGPT.setup.description') }}</span>
+      <!-- <span class="chatgpt-modal__content__title">{{ $t('ChatGPT.setup.title') }}</span>
+      <span class="chatgpt-modal__content__description">{{ $t('ChatGPT.setup.description') }}</span> -->
 
       <div class="chatgpt-modal__content__form">
         <unnnic-input
@@ -152,26 +154,36 @@
 
 <style lang="scss" scoped>
   .chatgpt-modal {
-    ::v-deep .unnnic-modal-container-background-body-description {
-      padding-bottom: $unnnic-spacing-stack-xs;
+    ::v-deep {
+      .container {
+        padding: $unnnic-squish-md !important;
+      }
+
+      .header {
+        margin-bottom: $unnnic-spacing-stack-nano !important;
+      }
+
+      .unnnic-modal-container-background {
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+        padding: 0 $unnnic-spacing-md;
+        max-height: 95vh;
+      }
+
+      .unnnic-modal-container-background-body {
+        border-radius: $unnnic-border-radius-sm $unnnic-border-radius-sm 0px 0px;
+      }
+
+      .unnnic-modal-container-background-body-description-container {
+        padding-bottom: $unnnic-spacing-md;
+      }
     }
 
     &__content {
       display: flex;
       flex-direction: column;
-
-      &__title {
-        font-family: $unnnic-font-family-secondary;
-        color: $unnnic-color-neutral-darkest;
-        font-weight: $unnnic-font-weight-black;
-        font-size: $unnnic-font-size-title-sm;
-        line-height: ($unnnic-font-size-title-sm + $unnnic-line-height-medium);
-        padding: $unnnic-spacing-stack-md 0;
-      }
-
-      &__description {
-        margin-bottom: $unnnic-spacing-stack-lg;
-      }
+      overflow: auto;
 
       &__form {
         display: flex;
@@ -192,6 +204,16 @@
             gap: $unnnic-spacing-stack-lg;
           }
         }
+      }
+    }
+
+    &__buttons {
+      display: flex;
+      flex: 1;
+      margin-top: $unnnic-spacing-md;
+
+      * {
+        flex: 1;
       }
     }
   }

--- a/tests/unit/specs/components/config/external/chatgpt/__snapshots__/Setup.spec.js.snap
+++ b/tests/unit/specs/components/config/external/chatgpt/__snapshots__/Setup.spec.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`components/config/external/chatgpt/Setup.vue should be rendered properly 1`] = `
-<unnnicmodal-stub showmodal="true" class="chatgpt-modal">
-  <div class="chatgpt-modal__content"><span class="chatgpt-modal__content__title">Integrate with ChatGPT</span> <span class="chatgpt-modal__content__description">To integrate, create a name, insert your API-Token and select one of the available versions</span>
+<unnnicmodal-stub text="Integrate with ChatGPT" description="To integrate, create a name, insert your API-Token and select one of the available versions" showmodal="true" class="chatgpt-modal">
+  <div class="chatgpt-modal__content">
     <div class="chatgpt-modal__content__form">
       <unnnic-input-stub placeholder="Insert a name" type="normal" value="" nativetype="text" label="Name" size="md" mask="" class="chatgpt-modal__content__form__input__name"></unnnic-input-stub>
       <unnnic-input-stub placeholder="Insert the Token" type="normal" value="" nativetype="text" label="Token" size="md" mask="" class="chatgpt-modal__content__form__input__token"></unnnic-input-stub>


### PR DESCRIPTION
- Modal was overflowing instead of adding a scroll into the content, now a scroll appears when the height is not enough to show the content