### PR TITLE
fix: always fetch vtexApp in whatsapp account tab

### DIFF
--- a/src/components/config/channels/whatsapp/components/tabs/AccountTab.vue
+++ b/src/components/config/channels/whatsapp/components/tabs/AccountTab.vue
@@ -223,9 +223,9 @@
           await this.getConfiguredApps({ params, skipLoading: true });
 
           if (!this.configuredApps) return;
-
-          this.vtexApp = this.configuredApps.find((app) => app.code === 'vtex');
         }
+
+        this.vtexApp = this.configuredApps.find((app) => app.code === 'vtex');
       },
       callAlert({ text, type }) {
         unnnicCallAlert({


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
In the WhatsApp connect catalog process, the Vtex app was not being assigned, making it unable to connect a new catalog

### Summary of Changes
<!--- Describe your changes in detail -->
Moved Vtex app variable assignment to be outside the if statement.