### PR TITLE
Fix: whatsapp templates - table height

### DIFF
--- a/src/components/whatsAppTemplates/Table.vue
+++ b/src/components/whatsAppTemplates/Table.vue
@@ -364,7 +364,7 @@
       },
       dropdownPosition(item) {
         const templates = this.whatsAppTemplates?.results || [];
-        return templates.findIndex((template) => template.uuid === item.uuid) > 7
+        return templates.findIndex((template) => template.uuid === item.uuid) > 1
           ? 'top-left'
           : 'bottom-left';
       },
@@ -426,7 +426,7 @@
       ::v-deep .scroll {
         overflow-x: hidden;
         flex: none;
-        height: 50vh;
+        min-height: 248px;
 
         padding-right: unset;
       }

--- a/src/components/whatsAppTemplates/Table.vue
+++ b/src/components/whatsAppTemplates/Table.vue
@@ -425,7 +425,8 @@
 
       ::v-deep .scroll {
         overflow-x: hidden;
-        overflow-y: auto;
+        flex: none;
+        height: 50vh;
 
         padding-right: unset;
       }

--- a/src/components/whatsAppTemplates/TableActionButton.vue
+++ b/src/components/whatsAppTemplates/TableActionButton.vue
@@ -128,6 +128,7 @@
 
       ::v-deep .unnnic-dropdown__content {
         width: max-content;
+        height: auto;
       }
 
       &__item {

--- a/tests/unit/specs/components/whatsAppTemplates/Table.spec.js
+++ b/tests/unit/specs/components/whatsAppTemplates/Table.spec.js
@@ -305,7 +305,7 @@ describe('components/whatsAppTemplates/Table.vue', () => {
         };
       });
 
-      const dropdownPosition = wrapper.vm.dropdownPosition({ uuid: '3' });
+      const dropdownPosition = wrapper.vm.dropdownPosition({ uuid: '1' });
       expect(dropdownPosition).toBe('bottom-left');
     });
 


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
Whatsapp templates table wasn`t adjusting the heigh to fit full page.

### Summary of Changes
At class .scroll: changed flex to none and set a fixed height of 50vh.
