### PR TITLE
fix: add business management permission to fb login

### DIFF
--- a/src/components/config/channels/facebook/Setup.vue
+++ b/src/components/config/channels/facebook/Setup.vue
@@ -119,8 +119,8 @@
         onLogin: false,
         loadingPages: false,
         appScopes: {
-          ig: 'instagram_basic,instagram_manage_messages,pages_manage_metadata,pages_messaging,pages_read_engagement,pages_show_list',
-          fba: 'pages_messaging,pages_show_list,pages_manage_metadata,pages_read_engagement',
+          ig: 'business_management,instagram_basic,instagram_manage_messages,pages_manage_metadata,pages_messaging,pages_read_engagement,pages_show_list',
+          fba: 'business_management,pages_messaging,pages_show_list,pages_manage_metadata,pages_read_engagement',
         },
       };
     },


### PR DESCRIPTION
## Description
Add required business-management permission into facebook login process for Facebook and Instagram applications

### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [X] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
Users are not able to proceed with the Facebook/Instagram integration.

### Summary of Changes
Added new business-management permission