### PR TITLE
[FLOWS - 2422] Allow the use of a variable at the beginning and the end of the body.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+2.1.7
+----------
+`2024-07-29 · 1 🐛 `
+
+### 🐛 Bug fixes
+- Fix: WhatsApp template form - Allow the use of a variable at the beginning and the end of the body.
+
 2.1.6
 ----------
 `2024-07-24 · 1 🐛 `

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weni-integrations",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/components/whatsAppTemplates/FormTabContentBody.vue
+++ b/src/components/whatsAppTemplates/FormTabContentBody.vue
@@ -39,8 +39,6 @@
 
   import {
     countVariables,
-    startsWithVariableRegex,
-    endsWithVariableRegex,
     singleBracketVariableRegex,
     incompleteStartBracketVariableRegex,
     incompleteEndBracketVariableRegex,
@@ -72,13 +70,6 @@
       },
       errorsList() {
         const errors = [];
-
-        if (
-          this.bodyContent.match(startsWithVariableRegex) ||
-          this.bodyContent.match(endsWithVariableRegex)
-        ) {
-          errors.push(this.$t('WhatsApp.templates.error.start_or_end_with_variable'));
-        }
 
         if (
           this.bodyContent.match(singleBracketVariableRegex) ||


### PR DESCRIPTION
## Description
### Type of Change
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
 Allow the use of a variable at the beginning and the end of the body.

### Summary of Changes
Remove rules that block the use of variables at the beginning and end of the body.
