### PR TITLE
Update iframe source in OtherApps component to use dynamic project and token values

### DIFF
--- a/src/tests/views/__snapshots__/OtherApps.spec.js.snap
+++ b/src/tests/views/__snapshots__/OtherApps.spec.js.snap
@@ -2,6 +2,6 @@
 
 exports[`OtherApps > matches snapshot 1`] = `
 "<div data-v-e28c1cb5="" class="container">
-  <div data-v-e28c1cb5="" class="flows-iframe"><img data-v-e28c1cb5="" class="logo" src="/src/assets/svgs/LogoWeniAnimada4.svg" alt=""></div><iframe data-v-e28c1cb5="" class="flows-iframe" src="undefined/weni/null/authenticate?next=/org/home/?flows_config_hide=configs" allow="clipboard-read; clipboard-write;" title="" style="border: 0px; display: none;"></iframe>
+  <div data-v-e28c1cb5="" class="flows-iframe"><img data-v-e28c1cb5="" class="logo" src="/src/assets/svgs/LogoWeniAnimada4.svg" alt=""></div><iframe data-v-e28c1cb5="" class="flows-iframe" src="undefined/weni/null/authenticate?access_token=null&amp;next=/org/home/?flows_config_hide=configs" allow="clipboard-read; clipboard-write;" title="" style="border: 0px; display: none;"></iframe>
 </div>"
 `;

--- a/src/views/OtherApps/index.vue
+++ b/src/views/OtherApps/index.vue
@@ -29,11 +29,11 @@
       };
     },
     computed: {
-      ...mapState(auth_store, ['flowOrg']),
+      ...mapState(auth_store, ['project', 'token']),
       iframeSrc() {
         return `${getEnv('VITE_APP_FLOWS_IFRAME_URL')}/weni/${
-          this.flowOrg
-        }/authenticate?next=/org/home/?flows_config_hide=configs`;
+          this.project
+        }/authenticate?access_token=${this.token}&next=/org/home/?flows_config_hide=configs`;
       },
     },
     methods: {


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
Now weni flows authenticate with a token as a query parameter and uses the project_uuid instead of flow_org_uuid

### Summary of Changes
Added token and project_uuid into the generated url
