### PR TITLE
[HS-983] Multiple Ways to Access Environment Variables

### DIFF
--- a/src/utils/env.js
+++ b/src/utils/env.js
@@ -1,4 +1,9 @@
 function getEnv(name) {
-  return window?.configs?.[name] || import.meta.env[name];
+  return (
+    window?.configs?.[name] ||
+    import.meta.env[name] ||
+    window?.configs?.[`VITE_APP_${name}`] ||
+    import.meta.env[`VITE_APP_${name}`]
+  );
 }
 export default getEnv;


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
In order to solve the hotjar integration problem, where it tried to access the `HOTJAR_ID` variable by omitting the `VITE_APP_` prefix, this PR aims to introduce the possibility of accessing environment variables by omitting the `VITE_APP_` prefix, making environment variables accessible in both ways, with or without the `VITE_APP_` prefix.

### Summary of Changes
<!--- Describe your changes in detail -->
* adds the possibility to access the environment variable also omitting the prefix `VITE_APP_`.