### PR TITLE
fix: add 'instagram_manage_comments' scope to Facebook app permissions

### DIFF
--- a/src/components/config/channels/facebook/Setup.vue
+++ b/src/components/config/channels/facebook/Setup.vue
@@ -119,7 +119,7 @@
         onLogin: false,
         loadingPages: false,
         appScopes: {
-          ig: 'business_management,instagram_basic,instagram_manage_messages,pages_manage_metadata,pages_messaging,pages_read_engagement,pages_show_list',
+          ig: 'business_management,instagram_basic,instagram_manage_messages,pages_manage_metadata,pages_messaging,pages_read_engagement,pages_show_list,instagram_manage_comments',
           fba: 'business_management,pages_messaging,pages_show_list,pages_manage_metadata,pages_read_engagement',
         },
       };


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [X] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
Add new permission to allow IG channels to reply to comments

### Summary of Changes
Added new permission in IG app scope permission list
