### PR TITLE
feat: enhance contact timeout validation in WWC configuration

### DIFF
--- a/src/components/config/channels/WWC/Config.vue
+++ b/src/components/config/channels/WWC/Config.vue
@@ -178,13 +178,18 @@
                     </div>
 
                     <transition name="fade">
-                      <unnnic-select-time
+                      <unnnic-input
                         v-show="enableContactTimeout"
-                        :modelValue="contactTimeout"
-                        :options="[]"
+                        v-model="contactTimeout"
                         class="app-config-wwc__tabs__settings-content__input__contactTimeout"
-                        type="normal"
                         @update:modelValue="handleContactTimeoutChange"
+                        mask="##:##"
+                        :type="invalidTime('contactTimeout') ? 'error' : 'normal'"
+                        :message="
+                          invalidTime('contactTimeout')
+                            ? $t('weniWebChat.config.contactTimeoutInvalidTime')
+                            : ''
+                        "
                       />
                     </transition>
                   </div>
@@ -220,6 +225,7 @@
                 type="primary"
                 size="large"
                 :text="$t('apps.config.save_changes')"
+                :disabled="invalidTime('contactTimeout') || loadingSave"
                 :loading="loadingSave"
                 @click="saveConfig"
               ></unnnic-button>
@@ -620,6 +626,20 @@
         const hours = Math.floor(contactTimeout / 60);
         const minutes = contactTimeout % 60;
         return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`;
+      },
+      invalidTime(key) {
+        if (!this.enableContactTimeout) {
+          return false;
+        }
+
+        const value = this.$data[key];
+
+        if (value === '00:00') {
+          return true;
+        }
+
+        const TIME_REGEX = /^([01]?[0-9]|2[0-3]):([0-5][0-9])$/;
+        return !value || value.length !== 5 || !TIME_REGEX.test(value);
       },
       clearAvatars() {
         this.simulatorAvatar = null;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -223,7 +223,8 @@
       "contactTimeoutInput": {
         "label": "Restart conversation after contact inactivity"
       },
-      "contactTimeoutToolTip": "If the contact remains inactive for the set amount of time, the conversation will automatically end.\nA new conversation will start if they interact again."
+      "contactTimeoutToolTip": "If the contact remains inactive for the set amount of time, the conversation will automatically end.\nA new conversation will start if they interact again.",
+      "contactTimeoutInvalidTime": "Value must be a timer with a maximum of 24 hours with the following format: HH:mm"
     },
     "simulator": {
       "chatTitle": "Chat Title",
@@ -461,7 +462,7 @@
       "templates": {
         "button": "See my templates",
         "title": "Templates",
-        "new_language":"New Language"	
+        "new_language": "New Language"
       },
       "catalog": {
         "button": "View list of catalogs",
@@ -522,7 +523,7 @@
           "add_language": "Add language",
           "duplicate_language": "Duplicate",
           "delete_language": "Delete",
-          "see_details":"See details"
+          "see_details": "See details"
         },
         "headers": {
           "name": "Name",
@@ -1079,7 +1080,6 @@
       "update_connected_catalog_status": "Failed to fetch catalog status, please try again later.",
       "select_five_sellers": "Please select up to 5 sellers.",
       "sync_sellers": "Unable to synchronize sellers at the moment, please try again later."
-
     },
     "success": {
       "connect_catalog": "Successfully connected VTEX catalog",
@@ -1106,7 +1106,6 @@
       }
     }
   },
-
   "channels": {
     "TWT": "Send and receive messages on Twitter using their Twitter Activity API. You will have to apply for Twitter API access and create a Twitter application.",
     "SL": "Add a Slack bot to send and receive messages to Slack users.",
@@ -1132,11 +1131,10 @@
     "WC": "Add a WeChat bot to send and receive messages to WeChat users for free. Your users will need an Android, Windows or iOS device and a WeChat account to send and receive messages.",
     "ZVS": "If you have a Zenvia SMS number, you can connect it to communicate with your contacts.",
     "ZVW": "If you have a Zenvia WhatsApp number, you can connect it to communicate with your WhatsApp contacts.",
-
-    "inputs":{
+    "inputs": {
       "KWA": {
         "number": {
-          "label": "Your enterprise WhatsApp number", 
+          "label": "Your enterprise WhatsApp number",
           "message": "",
           "placeholder": ""
         },
@@ -1180,14 +1178,14 @@
       },
       "MG": {
         "shortcode": {
-        "label": "The Messangi short code",
-        "placeholder": "Enter the shortcode",
-        "message": null
+          "label": "The Messangi short code",
+          "placeholder": "Enter the shortcode",
+          "message": null
         },
         "carrier_id": {
-        "label": "Carrier Id",
-        "placeholder": "Enter the carrier id",
-        "message": "The carrier id for the short code"
+          "label": "Carrier Id",
+          "placeholder": "Enter the carrier id",
+          "message": "The carrier id for the short code"
         },
         "public_key": {
           "label": "Public Key",
@@ -1207,9 +1205,9 @@
       },
       "PM": {
         "base_url": {
-        "label": "Base URL",
-        "placeholder": "Enter the base URL",
-        "message": "The base URL for PlayMobile"
+          "label": "Base URL",
+          "placeholder": "Enter the base URL",
+          "message": "The base URL for PlayMobile"
         },
         "shortcode": {
           "label": "Shortcode",
@@ -1401,37 +1399,37 @@
         }
       },
       "CM": {
-      "number": {
-        "label": "Número",
-        "message": "El número de teléfono o código corto de Click Mobile que estás conectando con el código de país. ej: +250788123124",
-        "placeholder": ""
+        "number": {
+          "label": "Número",
+          "message": "El número de teléfono o código corto de Click Mobile que estás conectando con el código de país. ej: +250788123124",
+          "placeholder": ""
+        },
+        "country": {
+          "label": "País",
+          "message": "",
+          "placeholder": ""
+        },
+        "username": {
+          "label": "ID de Usuario",
+          "message": "Tu user_id en Click Mobile",
+          "placeholder": ""
+        },
+        "password": {
+          "label": "Contraseña",
+          "message": "Tu contraseña en Click Mobile",
+          "placeholder": ""
+        },
+        "app_id": {
+          "label": "ID de la Aplicación",
+          "message": "Tu app_id en Click Mobile",
+          "placeholder": ""
+        },
+        "org_id": {
+          "label": "ID de la Organización",
+          "message": "Tu org_id en Click Mobile",
+          "placeholder": ""
+        }
       },
-      "country": {
-        "label": "País",
-        "message": "",
-        "placeholder": ""
-      },
-      "username": {
-        "label": "ID de Usuario",
-        "message": "Tu user_id en Click Mobile",
-        "placeholder": ""
-      },
-      "password": {
-        "label": "Contraseña",
-        "message": "Tu contraseña en Click Mobile",
-        "placeholder": ""
-      },
-      "app_id": {
-        "label": "ID de la Aplicación",
-        "message": "Tu app_id en Click Mobile",
-        "placeholder": ""
-      },
-      "org_id": {
-        "label": "ID de la Organización",
-        "message": "Tu org_id en Click Mobile",
-        "placeholder": ""
-      }
-    },
       "CT": {
         "country": {
           "type": "select",
@@ -1448,7 +1446,7 @@
           "label": "API Key",
           "message": "The API key for your integration as provided by Clickatell"
         }
-      }, 
+      },
       "D3": {
         "number": {
           "type": "input",
@@ -1595,45 +1593,45 @@
       }
     }
   },
-  "email": { 
+  "email": {
     "data": {
       "summary": "Connect your email and streamline customer service more easily."
     },
-  "config": {
-    "title": "Email",
-    "description": "Connect your email and automate customer support more easily.",
-    "config_solution": "Solution Configuration",
-    "config_solution_subtitle": "Fill in the fields below to integrate an email",
-    "select": "Select the email type",
-    "smpt_server": {
-      "title": "SMTP Server",
-      "description": "SMTP server address for sending emails."
-    },
-    "smpt_port": {
-      "title": "SMTP Port",
-      "description": "SMTP server communication port."
-    },
-    "imap_server": {
-      "title": "IMAP Server",
-      "description": "IMAP server address for sending emails."
-    },
-    "imap_port": {
-      "title": "IMAP Port",
-      "description": "IMAP server communication port."
-    },
-    "username": "Username",
-    "username_description": "The email used for authentication.",
-    "password": "Password"
-  }
-},
-"gmail": {
-  "setup": {
-    "title": "Connect to Gmail",
-    "description": "Click Continue to open the Gmail login page. After logging in, your account will be automatically integrated.",
-    "buttons": {
-      "cancel": "Cancel",
-      "continue": "Continue"
+    "config": {
+      "title": "Email",
+      "description": "Connect your email and automate customer support more easily.",
+      "config_solution": "Solution Configuration",
+      "config_solution_subtitle": "Fill in the fields below to integrate an email",
+      "select": "Select the email type",
+      "smpt_server": {
+        "title": "SMTP Server",
+        "description": "SMTP server address for sending emails."
+      },
+      "smpt_port": {
+        "title": "SMTP Port",
+        "description": "SMTP server communication port."
+      },
+      "imap_server": {
+        "title": "IMAP Server",
+        "description": "IMAP server address for sending emails."
+      },
+      "imap_port": {
+        "title": "IMAP Port",
+        "description": "IMAP server communication port."
+      },
+      "username": "Username",
+      "username_description": "The email used for authentication.",
+      "password": "Password"
+    }
+  },
+  "gmail": {
+    "setup": {
+      "title": "Connect to Gmail",
+      "description": "Click Continue to open the Gmail login page. After logging in, your account will be automatically integrated.",
+      "buttons": {
+        "cancel": "Cancel",
+        "continue": "Continue"
+      }
     }
   }
-}
 }

--- a/src/locales/es_es.json
+++ b/src/locales/es_es.json
@@ -223,7 +223,8 @@
       "contactTimeoutInput": {
         "label": "Reiniciar conversación después de inactividad del contacto"
       },
-      "contactTimeoutToolTip": "Si el contacto permanece inactivo durante el tiempo establecido, la conversación se cerrará automáticamente.\nUna nueva conversación comenzará si interactúan nuevamente."
+      "contactTimeoutToolTip": "Si el contacto permanece inactivo durante el tiempo establecido, la conversación se cerrará automáticamente.\nUna nueva conversación comenzará si interactúan nuevamente.",
+      "contactTimeoutInvalidTime": "El valor debe ser un temporizador con un máximo de 24 horas en el siguiente formato: HH:mm"
     },
     "simulator": {
       "chatTitle": "Título del chat",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -223,7 +223,8 @@
       "contactTimeoutInput": {
         "label": "Reiniciar conversa por inatividade do contato"
       },
-      "contactTimeoutToolTip": "Se o contato permanecer inativo pelo tempo definido, a conversa será encerrada automaticamente.\nUma nova conversa será iniciada caso ele volte a interagir."
+      "contactTimeoutToolTip": "Se o contato permanecer inativo pelo tempo definido, a conversa será encerrada automaticamente.\nUma nova conversa será iniciada caso ele volte a interagir.",
+      "contactTimeoutInvalidTime": "O valor deve ser um timer com um máximo de 24 horas no seguinte formato: HH:mm"
     },
     "simulator": {
       "chatTitle": "Título do Chat",


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [X] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
Select time had the time format based on the user browser language, so english users had the AM/PM variant, this as an issue since the contactTimeout is a timer and not a time

### Summary of Changes
- Replaced unnnic-select-time with unnnic-input for contact timeout input.
- Added validation for contact timeout format, ensuring it adheres to HH:mm and does not exceed 24 hours.
- Updated button state to disable when the contact timeout is invalid or while saving.
- Localized error message for invalid contact timeout in English, Spanish, and Portuguese.
