### PR TITLE
feat: add 'Add to Cart' option in WWC configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+3.11.2
+----------
+`2026-04-10 · 1 🎉`
+
+### 🎉 New features
+- feat(wwc): add 'Add to Cart' option in WWC configuration
+
 3.11.1
 ----------
 `2026-04-08 · 1 🔧`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "weni-integrations",
-  "version": "3.11.1",
+  "version": "3.11.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "weni-integrations",
-      "version": "3.11.1",
+      "version": "3.11.2",
       "dependencies": {
         "@babel/core": "^7.23.9",
         "@babel/eslint-parser": "^7.23.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weni-integrations",
-  "version": "3.11.1",
+  "version": "3.11.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/components/config/channels/WWC/Config.vue
+++ b/src/components/config/channels/WWC/Config.vue
@@ -66,6 +66,7 @@
             :initialTimeBetweenMessages="config.timeBetweenMessages"
             :initialNavigateIfSameDomain="config.navigateIfSameDomain"
             :initialConversationStartersPDP="config.conversationStartersPDP"
+            :initialAddToCart="config.addToCart"
             :loading="loadingSave"
             @update:embedded="updateConfig('embedded', $event)"
             @update:showFullScreenButton="updateConfig('showFullScreenButton', $event)"
@@ -80,6 +81,7 @@
             @update:timeBetweenMessages="updateConfig('timeBetweenMessages', $event)"
             @update:navigateIfSameDomain="updateConfig('navigateIfSameDomain', $event)"
             @update:conversationStartersPDP="updateConfig('conversationStartersPDP', $event)"
+            @update:addToCart="updateConfig('addToCart', $event)"
             @save="saveConfig"
             @cancel="closeConfig"
           />
@@ -197,6 +199,7 @@
     voiceModeEnabled: !!props.app.config.voiceMode?.enabled,
     elevenLabsVoiceId: props.app.config.voiceMode?.elevenLabs?.voiceId || null,
     elevenLabsApiKey: props.app.config.voiceMode?.elevenLabs?.apiKey || null,
+    addToCart: !!props.app.config.addToCart,
   });
 
   // Computed
@@ -283,6 +286,7 @@
           useConnectionOptimization: config.useConnectionOptimization,
           navigateIfSameDomain: config.navigateIfSameDomain,
           conversationStartersPDP: config.conversationStartersPDP,
+          addToCart: config.addToCart,
           embedded: config.embedded,
           mainColor: config.mainColor,
           profileAvatar: await imageForUpload(),

--- a/src/components/config/channels/WWC/components/tabs/PreferencesTab.vue
+++ b/src/components/config/channels/WWC/components/tabs/PreferencesTab.vue
@@ -8,17 +8,6 @@
           </h3>
 
           <unnnic-switch
-            v-model="navigateIfSameDomain"
-            size="small"
-            :textRight="$t('weniWebChat.config.navigate_if_same_domain.label')"
-            :helper="$t('weniWebChat.config.navigate_if_same_domain.helper')"
-          >
-            <template #suffix>
-              <p class="preferences-tab__switch-suffix">{{ $t('general.beta') }}</p>
-            </template>
-          </unnnic-switch>
-
-          <unnnic-switch
             v-model="embedded"
             size="small"
             :textRight="$t('weniWebChat.config.embedded_mode')"
@@ -49,6 +38,12 @@
             size="small"
             :textRight="$t('weniWebChat.config.use_connection_optimization')"
           />
+        </section>
+
+        <section class="preferences-tab__section">
+          <h3 class="preferences-tab__section-title">
+            {{ $t('weniWebChat.config.retail') }}
+          </h3>
 
           <unnnic-switch
             v-model="conversationStartersPDP"
@@ -60,22 +55,42 @@
               <p class="preferences-tab__switch-suffix">{{ $t('general.new') }}</p>
             </template>
           </unnnic-switch>
+
+          <unnnic-switch
+            v-model="navigateIfSameDomain"
+            size="small"
+            :textRight="$t('weniWebChat.config.navigate_if_same_domain.label')"
+            :helper="$t('weniWebChat.config.navigate_if_same_domain.helper')"
+          >
+            <template #suffix>
+              <p class="preferences-tab__switch-suffix">{{ $t('general.beta') }}</p>
+            </template>
+          </unnnic-switch>
+
+          <unnnic-switch
+            v-model="addToCart"
+            size="small"
+            :textRight="$t('weniWebChat.config.add_to_cart.label')"
+            :helper="$t('weniWebChat.config.add_to_cart.helper')"
+          >
+            <template #suffix>
+              <p class="preferences-tab__switch-suffix">{{ $t('general.beta') }}</p>
+            </template>
+          </unnnic-switch>
         </section>
 
-        <section class="preferences-tab__section">
+        <section class="preferences-tab__section" v-if="version === '2'">
           <h3 class="preferences-tab__section-title">
             {{ $t('weniWebChat.config.media') }}
           </h3>
 
           <unnnic-switch
-            v-if="version === '2'"
             v-model="showVoiceRecordingButton"
             size="small"
             :textRight="$t('weniWebChat.config.show_voice_recording_button')"
           />
 
           <unnnic-switch
-            v-if="version === '2'"
             v-model="showCameraButton"
             size="small"
             :textRight="$t('weniWebChat.config.show_camera_button')"
@@ -185,6 +200,7 @@
     initialTimeBetweenMessages: { type: Number, default: 1 },
     initialNavigateIfSameDomain: { type: Boolean, default: false },
     initialConversationStartersPDP: { type: Boolean, default: false },
+    initialAddToCart: { type: Boolean, default: false },
     loading: { type: Boolean, default: false },
   });
 
@@ -202,6 +218,7 @@
     'update:timeBetweenMessages',
     'update:navigateIfSameDomain',
     'update:conversationStartersPDP',
+    'update:addToCart',
     'save',
     'cancel',
   ]);
@@ -220,6 +237,7 @@
   const timeBetweenMessages = ref(props.initialTimeBetweenMessages);
   const navigateIfSameDomain = ref(props.initialNavigateIfSameDomain);
   const conversationStartersPDP = ref(props.initialConversationStartersPDP);
+  const addToCart = ref(props.initialAddToCart);
 
   // Computed
   const timeBetweenMessagesOptions = computed(() => [
@@ -264,6 +282,7 @@
   watch(keepHistory, (value) => emit('update:keepHistory', value));
   watch(navigateIfSameDomain, (value) => emit('update:navigateIfSameDomain', value));
   watch(conversationStartersPDP, (value) => emit('update:conversationStartersPDP', value));
+  watch(addToCart, (value) => emit('update:addToCart', value));
 
   watch(enableContactTimeout, (value) => {
     emit('update:enableContactTimeout', value);

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -192,6 +192,7 @@
       "preferences": "Preferences",
       "behavior": "Behavior",
       "media": "Media",
+      "retail": "Retail",
       "history": "Chat history & Inactivity",
       "script_tutorial": "To install Web Chat on your website, copy and paste this code above the last <<strong>/body</strong>> on your website.",
       "script_disclaimer": "The script will be available once the required basic settings have been completed.",
@@ -216,6 +217,10 @@
       "conversation_starters_pdp": {
         "label": "AI-Suggested Questions",
         "helper": "Displays quick-interaction buttons in the product page. The AI analyzes the SKU to automatically suggest the most relevant customer inquiries."
+      },
+      "add_to_cart": {
+        "label": "Add to cart on store",
+        "helper": "Shoppers can add AI-suggested products directly to the store's native cart instead of a Webchat-managed cart. Recommended for stores with custom cart or checkout flows."
       },
       "main_color": "Main color",
       "save_changes": "Save changes",

--- a/src/locales/es_es.json
+++ b/src/locales/es_es.json
@@ -192,6 +192,7 @@
       "preferences": "Preferencias",
       "behavior": "Comportamiento",
       "media": "Medios",
+      "retail": "Minorista",
       "history": "Historial de chat & Inactividad",
       "script_tutorial": "Para instalar Web Chat en su sitio web, copie y pegue este código encima del último <<strong>/body</strong>> en su sitio web.",
       "script_disclaimer": "El script estará disponible una vez que se completen los ajustes básicos requeridos.",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -193,6 +193,7 @@
       "behavior": "Comportamento",
       "history": "Histórico de chat & Inatividade",
       "media": "Mídia",
+      "retail": "Varejo",
       "script_tutorial": "Para instalar o Web Chat no seu site, copie e cole este código acima da última tag <<strong>/body</strong>> no seu site",
       "script_disclaimer": "O script estará disponível uma vez que os ajustes básicos necessários forem completados.",
       "download_script": "Baixar Script",

--- a/src/tests/components/config/channels/WWC/tabs/PreferencesTab.spec.js
+++ b/src/tests/components/config/channels/WWC/tabs/PreferencesTab.spec.js
@@ -55,8 +55,8 @@ describe('PreferencesTab', () => {
 
     it('should render all behavior switches', () => {
       const switches = wrapper.findAll('unnnic-switch-stub');
-      // navigateIfSameDomain, embedded, showFullScreenButton, startFullScreen, displayUnreadCount, useConnectionOptimization, conversationStartersPDP, keepHistory, enableContactTimeout
-      expect(switches.length).toBe(9);
+      // navigateIfSameDomain, embedded, showFullScreenButton, startFullScreen, displayUnreadCount, useConnectionOptimization, conversationStartersPDP, keepHistory, enableContactTimeout, addToCart
+      expect(switches.length).toBe(10);
     });
 
     it('should render form element for time between messages', () => {
@@ -120,8 +120,8 @@ describe('PreferencesTab', () => {
     it('should disable fullscreen switches when embedded is true', () => {
       wrapper = createWrapper({ initialEmbedded: true });
       const switches = wrapper.findAll('unnnic-switch-stub');
-      const fullscreenSwitch = switches[2];
-      const startFullscreenSwitch = switches[3];
+      const fullscreenSwitch = switches[1];
+      const startFullscreenSwitch = switches[2];
       expect(fullscreenSwitch.attributes('disabled')).toBeDefined();
       expect(startFullscreenSwitch.attributes('disabled')).toBeDefined();
     });
@@ -130,8 +130,8 @@ describe('PreferencesTab', () => {
       wrapper = createWrapper({ initialEmbedded: true });
       const switches = wrapper.findAll('unnnic-switch-stub');
       // The disabled attribute will be set (even if as "true" string)
+      expect(switches[1].attributes('disabled')).toBe('true');
       expect(switches[2].attributes('disabled')).toBe('true');
-      expect(switches[3].attributes('disabled')).toBe('true');
     });
   });
 


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context

Allow merchants to redirect "add to cart" actions to the store's native cart instead of the Webchat-managed cart, for stores with custom cart or checkout flows.

### Summary of Changes

- Added `addToCart` boolean config property (prop, emit, ref, watcher, save payload) across `Config.vue` and `PreferencesTab.vue`
- Created a new "Retail" section in the Preferences tab grouping "AI-Suggested Questions", "Navigate if same domain", and the new "Add to cart on store" toggles
- Moved `v-if="version === '2'"` from individual Media switches to the section wrapper
- Added `retail` and `add_to_cart` i18n keys (label + helper in `en`, section title in `pt_br` and `es_es`)
