### PR TITLE
feat: increase WWC appearance title maximum to 25 characters

### DIFF
--- a/src/components/config/channels/WWC/components/tabs/AppearanceTab.vue
+++ b/src/components/config/channels/WWC/components/tabs/AppearanceTab.vue
@@ -205,8 +205,8 @@
     if (!title.value?.trim()) {
       return t('errors.empty_input');
     }
-    if (title.value.length > 20) {
-      return 'By default, the maximum is 20 characters.';
+    if (title.value.length > 25) {
+      return 'By default, the maximum is 25 characters.';
     }
     return '';
   });

--- a/src/tests/components/config/channels/WWC/tabs/AppearanceTab.spec.js
+++ b/src/tests/components/config/channels/WWC/tabs/AppearanceTab.spec.js
@@ -172,7 +172,7 @@ describe('AppearanceTab', () => {
       expect(input.attributes('type')).toBe('error');
     });
 
-    it('should show error for title exceeding 20 characters', async () => {
+    it('should show error for title exceeding 25 characters', async () => {
       wrapper = createWrapper({ initialTitle: 'This is a very long title exceeding limit' });
       await wrapper.vm.$nextTick();
       const input = wrapper.find('unnnic-input-stub');
@@ -186,8 +186,8 @@ describe('AppearanceTab', () => {
       expect(input.attributes('type')).toBe('normal');
     });
 
-    it('should show normal type for title with exactly 20 characters', async () => {
-      wrapper = createWrapper({ initialTitle: '12345678901234567890' });
+    it('should show normal type for title with exactly 25 characters', async () => {
+      wrapper = createWrapper({ initialTitle: '1234567890123456789012345' });
       await wrapper.vm.$nextTick();
       const input = wrapper.find('unnnic-input-stub');
       expect(input.attributes('type')).toBe('normal');


### PR DESCRIPTION
## Description
### Type of Change
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
The WWC (Weni Web Chat) appearance title was previously capped at 20 characters, which was restrictive for common brand and channel names. Raising the limit to 25 gives users more room while keeping the header layout intact.

### Summary of Changes
- Update the title validation in `AppearanceTab.vue` so titles up to 25 characters are accepted (was 20).
- Update the inline error message to reflect the new 25-character limit.
- Update the related unit tests (`AppearanceTab.spec.js`) so the boundary case and test descriptions match the new limit.


Made with [Cursor](https://cursor.com)