### PR TITLE
fix(wwc): show delete option for saved avatar and custom css

### DIFF
--- a/src/components/config/channels/WWC/Config.vue
+++ b/src/components/config/channels/WWC/Config.vue
@@ -220,11 +220,15 @@
   }
 
   async function imageForUpload() {
-    let avatar = config.avatarFile;
-    if (typeof config.avatarFile === 'string') {
-      avatar = await dataUrlToFile(config.avatarFile, 'avatar');
+    const avatar = config.avatarFile;
+    if (!avatar) {
+      return '';
     }
-    return toBase64(avatar);
+    let file = avatar;
+    if (typeof avatar === 'string') {
+      file = await dataUrlToFile(avatar, 'avatar');
+    }
+    return toBase64(file);
   }
 
   function contactTimeoutInMinutes() {
@@ -291,7 +295,7 @@
           mainColor: config.mainColor,
           profileAvatar: await imageForUpload(),
           contactTimeout: contactTimeoutInMinutes(),
-          customCss: config.customCss,
+          customCss: config.customCss || '',
           version: config.version,
           voiceMode: {
             enabled: config.voiceModeEnabled,

--- a/src/components/config/channels/WWC/components/tabs/AppearanceTab.vue
+++ b/src/components/config/channels/WWC/components/tabs/AppearanceTab.vue
@@ -60,7 +60,7 @@
         <div class="appearance-tab__upload-section">
           <unnnic-label :label="$t('weniWebChat.config.avatar_image')" />
           <unnnic-upload-area
-            v-model="avatarFiles"
+            :files="avatarFiles"
             :acceptMultiple="false"
             supportedFormats=".png,.jpg,.jpeg"
             :maximumUploads="1"
@@ -76,7 +76,7 @@
         <div class="appearance-tab__upload-section">
           <unnnic-label :label="$t('weniWebChat.config.custom_css')" />
           <unnnic-upload-area
-            v-model="cssFiles"
+            :files="cssFiles"
             :acceptMultiple="false"
             supportedFormats=".css"
             :maximumUploads="1"

--- a/src/tests/components/config/channels/WWC/Config.spec.js
+++ b/src/tests/components/config/channels/WWC/Config.spec.js
@@ -406,6 +406,44 @@ describe('wwcConfig Component', () => {
       expect(callArg.payload.config.conversationStartersPDP).toBe(true);
     });
 
+    it('should send empty profileAvatar when the user clears an existing avatar', async () => {
+      wrapper = createWrapper({
+        config: { profileAvatar: 'https://example.com/avatar.png' },
+      });
+      const updateAppConfigSpy = vi.spyOn(store, 'updateAppConfig').mockResolvedValue();
+      vi.spyOn(store, 'getApp').mockResolvedValue();
+      store.currentApp = { config: { title: 'Test Title' } };
+
+      const appearanceTab = wrapper.findComponent({ name: 'AppearanceTab' });
+      await appearanceTab.vm.$emit('update:avatarFile', null);
+      await appearanceTab.vm.$emit('update:avatarBase64', null);
+      await appearanceTab.vm.$emit('save');
+      await flushPromises();
+
+      expect(updateAppConfigSpy).toHaveBeenCalled();
+      const callArg = updateAppConfigSpy.mock.calls[0][0];
+      expect(callArg.payload.config.profileAvatar).toBe('');
+    });
+
+    it('should send empty customCss when the user clears existing custom css', async () => {
+      wrapper = createWrapper({
+        config: { customCss: 'https://example.com/custom.css' },
+      });
+      const updateAppConfigSpy = vi.spyOn(store, 'updateAppConfig').mockResolvedValue();
+      vi.spyOn(store, 'getApp').mockResolvedValue();
+      store.currentApp = { config: { title: 'Test Title' } };
+
+      const appearanceTab = wrapper.findComponent({ name: 'AppearanceTab' });
+      await appearanceTab.vm.$emit('update:cssFile', null);
+      await appearanceTab.vm.$emit('update:customCss', null);
+      await appearanceTab.vm.$emit('save');
+      await flushPromises();
+
+      expect(updateAppConfigSpy).toHaveBeenCalled();
+      const callArg = updateAppConfigSpy.mock.calls[0][0];
+      expect(callArg.payload.config.customCss).toBe('');
+    });
+
     it('should emit setConfirmation false on successful save', async () => {
       vi.spyOn(store, 'updateAppConfig').mockResolvedValue();
       vi.spyOn(store, 'getApp').mockResolvedValue();

--- a/src/tests/components/config/channels/WWC/tabs/AppearanceTab.spec.js
+++ b/src/tests/components/config/channels/WWC/tabs/AppearanceTab.spec.js
@@ -1,4 +1,4 @@
-import { shallowMount } from '@vue/test-utils';
+import { shallowMount, flushPromises } from '@vue/test-utils';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import AppearanceTab from '@/components/config/channels/WWC/components/tabs/AppearanceTab.vue';
 import i18n from '@/utils/plugins/i18n';
@@ -57,6 +57,9 @@ describe('AppearanceTab', () => {
       props: { ...defaultProps, ...props },
     });
   };
+
+  const findUploadAreas = (wrapperInstance) =>
+    wrapperInstance.findAllComponents({ name: 'UnnnicUploadArea' });
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -324,6 +327,40 @@ describe('AppearanceTab', () => {
       const avatarUpload = uploadAreas[0];
       expect(avatarUpload.attributes('candelete')).toBe('true');
     });
+
+    it('should pass the existing avatar to the upload area when initialAvatarBase64 is provided', async () => {
+      wrapper = createWrapper({
+        initialAvatarBase64: 'https://example.com/avatar.png',
+      });
+      await flushPromises();
+
+      const avatarUpload = findUploadAreas(wrapper)[0];
+      expect(avatarUpload.attributes('files')).toBe('[object File]');
+    });
+
+    it('should not populate the upload area when initialAvatarBase64 is missing', async () => {
+      wrapper = createWrapper({ initialAvatarBase64: null });
+      await flushPromises();
+
+      const avatarUpload = findUploadAreas(wrapper)[0];
+      expect(avatarUpload.attributes('files') || '').toBe('');
+    });
+
+    it('should emit null update:avatarFile and update:avatarBase64 when the upload area clears the file', async () => {
+      wrapper = createWrapper({
+        initialAvatarBase64: 'https://example.com/avatar.png',
+      });
+      await flushPromises();
+
+      const avatarUpload = findUploadAreas(wrapper)[0];
+      await avatarUpload.vm.$emit('fileChange', []);
+      await flushPromises();
+
+      expect(wrapper.emitted('update:avatarFile')).toBeTruthy();
+      expect(wrapper.emitted('update:avatarFile').at(-1)).toEqual([null]);
+      expect(wrapper.emitted('update:avatarBase64')).toBeTruthy();
+      expect(wrapper.emitted('update:avatarBase64').at(-1)).toEqual([null]);
+    });
   });
 
   describe('CSS upload', () => {
@@ -350,6 +387,30 @@ describe('AppearanceTab', () => {
       const uploadAreas = wrapper.findAll('unnnic-upload-area-stub');
       const cssUpload = uploadAreas[1];
       expect(cssUpload.attributes('acceptmultiple')).toBe('false');
+    });
+
+    it('should pass the existing CSS file to the upload area when initialCssFile is provided', async () => {
+      const existingCssFile = new File(['body {}'], 'style.css', { type: 'text/css' });
+      wrapper = createWrapper({ initialCssFile: existingCssFile });
+      await flushPromises();
+
+      const cssUpload = findUploadAreas(wrapper)[1];
+      expect(cssUpload.attributes('files')).toBe('[object File]');
+    });
+
+    it('should emit null update:cssFile and update:customCss when the upload area clears the file', async () => {
+      const existingCssFile = new File(['body {}'], 'style.css', { type: 'text/css' });
+      wrapper = createWrapper({ initialCssFile: existingCssFile });
+      await flushPromises();
+
+      const cssUpload = findUploadAreas(wrapper)[1];
+      await cssUpload.vm.$emit('fileChange', []);
+      await flushPromises();
+
+      expect(wrapper.emitted('update:cssFile')).toBeTruthy();
+      expect(wrapper.emitted('update:cssFile').at(-1)).toEqual([null]);
+      expect(wrapper.emitted('update:customCss')).toBeTruthy();
+      expect(wrapper.emitted('update:customCss').at(-1)).toEqual([null]);
     });
   });
 


### PR DESCRIPTION
## Description
### Type of Change
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
When a WWC app already had a saved `profileAvatar` (or `customCss`), the config UI never rendered the file card with the delete icon, so users couldn't remove it. Root cause: `unnnic-upload-area` still uses the Vue 2 `model` option, which is ignored in Vue 3, so `v-model="avatarFiles"` never reached the component's `files` prop.

### Summary of Changes
- `AppearanceTab.vue`: bind the avatar/CSS upload areas with `:files` instead of `v-model` so the existing file reaches the component and the delete icon is rendered.
- `Config.vue`: send `""` for `profileAvatar` / `customCss` when cleared, so the backend can treat it as an explicit removal signal (paired with [weni-integrations-engine#793](https://github.com/weni-ai/weni-integrations-engine/pull/793)).
- Tests: added coverage for the initial file rendering, the clear flow, and the empty-string removal signal in the save payload. Full suite green (684/684).

Made with [Cursor](https://cursor.com)