### PR TITLE
fix(wwc): send empty string when clearing subtitle and other appearance text fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+3.11.4
+----------
+`2026-04-24 · 1 🐛`
+
+### 🐛 Bug fixes
+- fix(wwc): send empty string when clearing subtitle and other appearance text fields
+
 3.11.3
 ----------
 `2026-04-24 · 1 🎉 · 2 🐛`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "weni-integrations",
-  "version": "3.11.3",
+  "version": "3.11.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "weni-integrations",
-      "version": "3.11.3",
+      "version": "3.11.4",
       "dependencies": {
         "@babel/core": "^7.23.9",
         "@babel/eslint-parser": "^7.23.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weni-integrations",
-  "version": "3.11.3",
+  "version": "3.11.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/components/config/channels/WWC/Config.vue
+++ b/src/components/config/channels/WWC/Config.vue
@@ -276,10 +276,10 @@
       payload: {
         config: {
           title: config.title,
-          subtitle: config.subtitle || null,
-          initPayload: config.initPayload || null,
-          tooltipMessage: config.tooltipMessage || null,
-          inputTextFieldHint: config.inputTextFieldHint || null,
+          subtitle: config.subtitle || '',
+          initPayload: config.initPayload || '',
+          tooltipMessage: config.tooltipMessage || '',
+          inputTextFieldHint: config.inputTextFieldHint || '',
           showFullScreenButton: config.showFullScreenButton,
           displayUnreadCount: config.displayUnreadCount,
           timeBetweenMessages: config.timeBetweenMessages,

--- a/src/tests/components/config/channels/WWC/Config.spec.js
+++ b/src/tests/components/config/channels/WWC/Config.spec.js
@@ -444,6 +444,29 @@ describe('wwcConfig Component', () => {
       expect(callArg.payload.config.customCss).toBe('');
     });
 
+    it.each([
+      ['subtitle', 'update:subtitle'],
+      ['initPayload', 'update:initPayload'],
+      ['tooltipMessage', 'update:tooltipMessage'],
+      ['inputTextFieldHint', 'update:inputTextFieldHint'],
+    ])(
+      'should send empty %s when the user clears an existing value',
+      async (configKey, eventName) => {
+        const updateAppConfigSpy = vi.spyOn(store, 'updateAppConfig').mockResolvedValue();
+        vi.spyOn(store, 'getApp').mockResolvedValue();
+        store.currentApp = { config: { title: 'Test Title' } };
+
+        const appearanceTab = wrapper.findComponent({ name: 'AppearanceTab' });
+        await appearanceTab.vm.$emit(eventName, '');
+        await appearanceTab.vm.$emit('save');
+        await flushPromises();
+
+        expect(updateAppConfigSpy).toHaveBeenCalled();
+        const callArg = updateAppConfigSpy.mock.calls[0][0];
+        expect(callArg.payload.config[configKey]).toBe('');
+      },
+    );
+
     it('should emit setConfirmation false on successful save', async () => {
       vi.spyOn(store, 'updateAppConfig').mockResolvedValue();
       vi.spyOn(store, 'getApp').mockResolvedValue();


### PR DESCRIPTION
## Description
### Type of Change
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
Clearing the `subtitle`, `initPayload`, `tooltipMessage`, or `inputTextFieldHint` fields in the Weni Web Chat appearance tab had no effect: the old value kept coming back after save. Root cause was the interaction between two layers — `Config.vue` coalesced empty inputs to `null`, `removeEmpty` stripped that `null` from the request payload, and the engine's `_merge_with_existing_config` then re-injected the previous value for any missing key. `customCss` already avoided this trap by sending `""`; this change applies the same pattern to the four affected text fields.

### Summary of Changes
- `Config.vue`: send `""` (instead of `null`) for `subtitle`, `initPayload`, `tooltipMessage`, and `inputTextFieldHint` in the save payload, so the key survives `removeEmpty` and the backend receives an explicit removal signal.
- Tests: added a parameterized `it.each` block in `Config.spec.js` that clears each of the four fields and asserts the corresponding `payload.config[field] === ''` reaches `updateAppConfig`. Full WWC suite green (69/69).
- Paired with [weni-integrations-engine#794](https://github.com/weni-ai/weni-integrations-engine/pull/794), which adds `allow_blank=True` to the same four serializer fields so the backend accepts the empty string.

Made with [Cursor](https://cursor.com)