### PR TITLE
feat(wwc): add v3 webchat script URL and make it default for new apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+3.11.5
+----------
+`2026-04-28 · 1 🔧`
+
+### 🔧 Improvements
+- feat(wwc): add v3 webchat script URL and make it default for new apps
+
 3.11.4
 ----------
 `2026-04-24 · 1 🐛`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "weni-integrations",
-  "version": "3.11.4",
+  "version": "3.11.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "weni-integrations",
-      "version": "3.11.4",
+      "version": "3.11.5",
       "dependencies": {
         "@babel/core": "^7.23.9",
         "@babel/eslint-parser": "^7.23.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weni-integrations",
-  "version": "3.11.4",
+  "version": "3.11.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/components/IntegrateButton/index.vue
+++ b/src/components/IntegrateButton/index.vue
@@ -96,7 +96,7 @@
 
         if (code === 'wwc') {
           payload.config = {
-            version: '2',
+            version: '3',
             useConnectionOptimization: true,
           };
         }

--- a/src/components/config/channels/WWC/components/tabs/PreferencesTab.vue
+++ b/src/components/config/channels/WWC/components/tabs/PreferencesTab.vue
@@ -79,7 +79,7 @@
           </unnnic-switch>
         </section>
 
-        <section class="preferences-tab__section" v-if="version === '2'">
+        <section class="preferences-tab__section" v-if="isVersionTwoOrAbove">
           <h3 class="preferences-tab__section-title">
             {{ $t('weniWebChat.config.media') }}
           </h3>
@@ -258,6 +258,8 @@
     if (!enableContactTimeout.value) return false;
     return isInvalidTime(contactTimeout.value);
   });
+
+  const isVersionTwoOrAbove = computed(() => Number(props.version) >= 2);
 
   // Methods
   function handleTimeBetweenMessagesChange(value) {

--- a/src/components/config/channels/WWC/constants.js
+++ b/src/components/config/channels/WWC/constants.js
@@ -3,6 +3,7 @@ export const DEFAULT_COLOR = '#009E96';
 export const WEBCHAT_SCRIPT_URLS = {
   v1: 'https://storage.googleapis.com/push-webchat/wwc-latest.js',
   v2: 'https://cdn.cloud.weni.ai/webchat-latest.umd.js',
+  v3: 'https://cdn.cloud.weni.ai/v3/webchat-latest.umd.js',
 };
 
 export const TIME_BETWEEN_MESSAGES_OPTIONS = [
@@ -50,7 +51,7 @@ export function generateScriptCode(config) {
   if (!config?.script) return '';
 
   const version = config.version ?? '1';
-  const scriptUrl = version === '2' ? WEBCHAT_SCRIPT_URLS.v2 : WEBCHAT_SCRIPT_URLS.v1;
+  const scriptUrl = WEBCHAT_SCRIPT_URLS[`v${version}`] || WEBCHAT_SCRIPT_URLS.v1;
 
   return `<script>
   (function (d, s, u, w, v) {

--- a/src/tests/components/IntegrateButton.spec.js
+++ b/src/tests/components/IntegrateButton.spec.js
@@ -67,6 +67,22 @@ describe('IntegrateButton.vue', () => {
     expect(wrapper.vm.loadingCreateApp).toBe(false);
   });
 
+  it('creates wwc apps with v3 default config', async () => {
+    const createAppSpy = vi.spyOn(wrapper.vm, 'createApp').mockResolvedValue({});
+
+    await wrapper.vm.addApp({ code: 'wwc', config_design: 'popup' });
+    expect(createAppSpy).toHaveBeenCalledWith({
+      code: 'wwc',
+      payload: {
+        project_uuid: 'test-project',
+        config: {
+          version: '3',
+          useConnectionOptimization: true,
+        },
+      },
+    });
+  });
+
   it('calls callErrorModal when errorCreateApp is present', async () => {
     const errorModalSpy = vi.spyOn(wrapper.vm, 'callErrorModal');
     Object.defineProperty(wrapper.vm, 'errorCreateApp', {

--- a/src/tests/components/config/channels/WWC/constants.spec.js
+++ b/src/tests/components/config/channels/WWC/constants.spec.js
@@ -19,11 +19,12 @@ describe('WWC constants', () => {
   });
 
   describe('WEBCHAT_SCRIPT_URLS', () => {
-    it('should have v1 and v2 URLs', () => {
+    it('should have v1, v2 and v3 URLs', () => {
       expect(WEBCHAT_SCRIPT_URLS.v1).toBe(
         'https://storage.googleapis.com/push-webchat/wwc-latest.js',
       );
       expect(WEBCHAT_SCRIPT_URLS.v2).toBe('https://cdn.cloud.weni.ai/webchat-latest.umd.js');
+      expect(WEBCHAT_SCRIPT_URLS.v3).toBe('https://cdn.cloud.weni.ai/v3/webchat-latest.umd.js');
     });
   });
 
@@ -98,8 +99,23 @@ describe('WWC constants', () => {
       expect(result).toContain('https://test.script.url');
     });
 
+    it('should generate script code for v3', () => {
+      const config = { script: 'https://test.script.url', version: '3' };
+      const result = generateScriptCode(config);
+
+      expect(result).toContain('https://cdn.cloud.weni.ai/v3/webchat-latest.umd.js');
+      expect(result).toContain('https://test.script.url');
+    });
+
     it('should default to v1 if version is not specified', () => {
       const config = { script: 'https://test.script.url' };
+      const result = generateScriptCode(config);
+
+      expect(result).toContain('https://storage.googleapis.com/push-webchat/wwc-latest.js');
+    });
+
+    it('should fall back to v1 for unknown versions', () => {
+      const config = { script: 'https://test.script.url', version: '99' };
       const result = generateScriptCode(config);
 
       expect(result).toContain('https://storage.googleapis.com/push-webchat/wwc-latest.js');

--- a/src/tests/components/config/channels/WWC/tabs/PreferencesTab.spec.js
+++ b/src/tests/components/config/channels/WWC/tabs/PreferencesTab.spec.js
@@ -80,7 +80,7 @@ describe('PreferencesTab', () => {
       expect(wrapper.find('.preferences-tab__switches').exists()).toBe(true);
     });
 
-    it('should render three sections (behavior, media and history)', () => {
+    it('should render three sections when version is v1 (behavior, retail, history)', () => {
       const sections = wrapper.findAll('.preferences-tab__section');
       expect(sections.length).toBe(3);
     });
@@ -329,6 +329,38 @@ describe('PreferencesTab', () => {
   describe('contact timeout header', () => {
     it('should render contact timeout header', () => {
       expect(wrapper.find('.preferences-tab__contact-timeout-header').exists()).toBe(true);
+    });
+  });
+
+  describe('version-based media section', () => {
+    it('should not render media section when version is v1', () => {
+      wrapper = createWrapper({ version: '1' });
+      const sections = wrapper.findAll('.preferences-tab__section');
+      expect(sections.length).toBe(3);
+      const switches = wrapper.findAll('unnnic-switch-stub');
+      expect(switches.length).toBe(10);
+    });
+
+    it('should render media section when version is v2', () => {
+      wrapper = createWrapper({ version: '2' });
+      const sections = wrapper.findAll('.preferences-tab__section');
+      expect(sections.length).toBe(4);
+      const switches = wrapper.findAll('unnnic-switch-stub');
+      expect(switches.length).toBe(12);
+    });
+
+    it('should render media section when version is v3', () => {
+      wrapper = createWrapper({ version: '3' });
+      const sections = wrapper.findAll('.preferences-tab__section');
+      expect(sections.length).toBe(4);
+      const switches = wrapper.findAll('unnnic-switch-stub');
+      expect(switches.length).toBe(12);
+    });
+
+    it('should fall back to hiding media section when version is not numeric', () => {
+      wrapper = createWrapper({ version: 'not-a-number' });
+      const sections = wrapper.findAll('.preferences-tab__section');
+      expect(sections.length).toBe(3);
     });
   });
 });


### PR DESCRIPTION
## Description
### Type of Change
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context

Introduce a v3 Weni Web Chat script URL (`https://cdn.cloud.weni.ai/v3/webchat-latest.umd.js`) and make it the default for newly created WWC apps. The v3 widget only changes the script URL — everything else (preferences, voice mode, `connectOn`, etc.) is the same as v2. Existing apps explicitly configured on v1 or v2 must keep their script and their behavior; legacy apps that never stored a `version` key must also stay on v1 (no silent upgrade).

### Summary of Changes

- `src/components/config/channels/WWC/constants.js`: add `v3` to `WEBCHAT_SCRIPT_URLS` and resolve the script URL from the map via `WEBCHAT_SCRIPT_URLS[\`v${version}\`] || WEBCHAT_SCRIPT_URLS.v1`. Missing-version fallback stays `'1'`.
- `src/components/config/channels/WWC/components/tabs/PreferencesTab.vue`: replace the `v-if="version === '2'"` guard on the media section with a `isVersionTwoOrAbove` computed backed by `Number(props.version) >= 2` so the section also shows for v3. Prop default remains `'1'`.
- `src/components/IntegrateButton/index.vue`: new WWC apps are now created with `config: { version: '3', useConnectionOptimization: true }`.
- `Config.vue` is intentionally left untouched: its `version: props.app.config.version || '1'` fallback preserves v1 rendering for legacy apps that have no stored `version`; new apps already carry `version: '3'` in their config from `IntegrateButton`.
- Tests:
  - `constants.spec.js`: assert the new `v3` URL and add `generateScriptCode` coverage for `version: '3'` + unknown-version fallback.
  - `PreferencesTab.spec.js`: new `version-based media section` describe with explicit v1 / v2 / v3 / non-numeric cases (3 vs 4 sections, 10 vs 12 switches).
  - `IntegrateButton.spec.js`: add `creates wwc apps with v3 default config` case asserting the payload shape.
  - Full WWC suite and IntegrateButton suite green (80/80).
- Paired with [weni-integrations-engine#795](https://github.com/weni-ai/weni-integrations-engine/pull/795), which keeps v1/v2 behavior intact and extends the `connectOn` rule to v2+ via numeric version comparison on the backend.

Made with [Cursor](https://cursor.com)