### PR TITLE
✨ Introduce Dedicated Voice Mode Configuration Tab

### DIFF
--- a/rspack.config.cjs
+++ b/rspack.config.cjs
@@ -17,7 +17,7 @@ module.exports = defineConfig({
     port: 5173,
     historyApiFallback: true,
     hot: true,
-    liveReload: false,
+    liveReload: true,
     compress: true,
   },
   output: {

--- a/src/components/config/channels/WWC/Config.vue
+++ b/src/components/config/channels/WWC/Config.vue
@@ -87,14 +87,28 @@
           />
         </template>
 
+        <template v-if="isVoiceModeAvailable" #tab-head-voice-mode>
+          {{ $t('weniWebChat.config.voice_mode.title') }}
+        </template>
+        <template v-if="isVoiceModeAvailable" #tab-panel-voice-mode>
+          <VoiceModeTab
+            :initialVoiceModeEnabled="config.voiceModeEnabled"
+            :initialElevenLabsVoiceId="config.elevenLabsVoiceId"
+            :initialElevenLabsApiKey="config.elevenLabsApiKey"
+            :loading="loadingSave"
+            @update:voiceModeEnabled="updateConfig('voiceModeEnabled', $event)"
+            @update:elevenLabsVoiceId="updateConfig('elevenLabsVoiceId', $event)"
+            @update:elevenLabsApiKey="updateConfig('elevenLabsApiKey', $event)"
+            @save="saveConfig"
+            @cancel="closeConfig"
+          />
+        </template>
+
         <template #tab-head-integration> {{ $t('weniWebChat.config.script') }} </template>
         <template #tab-panel-integration>
           <IntegrationTab
             :appConfig="selectedApp.config"
             :title="config.title"
-            @update:voiceModeEnabled="updateConfig('voiceModeEnabled', $event)"
-            @update:elevenLabsVoiceId="updateConfig('elevenLabsVoiceId', $event)"
-            @update:elevenLabsApiKey="updateConfig('elevenLabsApiKey', $event)"
             :loading="loadingSave"
             @save="saveConfig"
             @cancel="closeConfig"
@@ -139,6 +153,7 @@
   import { DEFAULT_COLOR, formatContactTimeout, parseContactTimeout } from './constants';
   import AppearanceTab from './components/tabs/AppearanceTab.vue';
   import PreferencesTab from './components/tabs/PreferencesTab.vue';
+  import VoiceModeTab from './components/tabs/VoiceModeTab.vue';
   import IntegrationTab from './components/tabs/IntegrationTab.vue';
   import WwcSimulator from './Simulator.vue';
 
@@ -203,7 +218,14 @@
   });
 
   // Computed
-  const configTabs = computed(() => ['appearance', 'preferences', 'integration']);
+  const isVoiceModeAvailable = computed(() => Number(config.version) >= 2);
+
+  const configTabs = computed(() => {
+    const tabs = ['appearance', 'preferences'];
+    if (isVoiceModeAvailable.value) tabs.push('voice-mode');
+    tabs.push('integration');
+    return tabs;
+  });
 
   const chatSubtitle = computed(() => config.subtitle || ' ');
 

--- a/src/components/config/channels/WWC/Config.vue
+++ b/src/components/config/channels/WWC/Config.vue
@@ -218,7 +218,7 @@
   });
 
   // Computed
-  const isVoiceModeAvailable = computed(() => Number(config.version) >= 2);
+  const isVoiceModeAvailable = computed(() => Number(config.version) >= 3);
 
   const configTabs = computed(() => {
     const tabs = ['appearance', 'preferences'];

--- a/src/components/config/channels/WWC/components/tabs/IntegrationTab.vue
+++ b/src/components/config/channels/WWC/components/tabs/IntegrationTab.vue
@@ -29,36 +29,6 @@
       @click="downloadScript"
     />
 
-    <section class="integration-tab__voice-mode-section">
-      <h3 class="integration-tab__voice-mode-title">
-        {{ $t('weniWebChat.config.voice_mode.title') }}
-      </h3>
-
-      <unnnic-switch
-        v-model="voiceModeEnabled"
-        size="small"
-        :textRight="$t('weniWebChat.config.voice_mode.enabled')"
-      />
-
-      <section class="integration-tab__voice-mode-fields">
-        <unnnic-input
-          nativeType="password"
-          class="integration-tab__voice-mode-field"
-          v-model="elevenLabsApiKey"
-          :label="$t('weniWebChat.config.voice_mode.elevenLabsApiKey.label')"
-          :placeholder="$t('weniWebChat.config.voice_mode.elevenLabsApiKey.placeholder')"
-          :disabled="!voiceModeEnabled"
-        />
-        <unnnic-input
-          class="integration-tab__voice-mode-field"
-          v-model="elevenLabsVoiceId"
-          :label="$t('weniWebChat.config.voice_mode.elevenLabsVoiceId.label')"
-          :placeholder="$t('weniWebChat.config.voice_mode.elevenLabsVoiceId.placeholder')"
-          :disabled="!voiceModeEnabled"
-        />
-      </section>
-    </section>
-
     <div class="integration-tab__buttons">
       <unnnic-button
         type="tertiary"
@@ -78,7 +48,7 @@
 </template>
 
 <script setup>
-  import { computed, ref, watch } from 'vue';
+  import { computed } from 'vue';
   import { generateScriptCode } from '../../constants';
 
   const props = defineProps({
@@ -96,17 +66,10 @@
     },
   });
 
-  const emit = defineEmits([
-    'update:voiceModeEnabled',
-    'update:elevenLabsVoiceId',
-    'update:elevenLabsApiKey',
-  ]);
+  const emit = defineEmits(['save', 'cancel']);
 
   // Computed
   const scriptCode = computed(() => generateScriptCode(props.appConfig));
-  const voiceModeEnabled = ref(!!props.appConfig.voiceMode?.enabled);
-  const elevenLabsVoiceId = ref(props.appConfig.voiceMode?.elevenLabs?.voiceId);
-  const elevenLabsApiKey = ref(props.appConfig.voiceMode?.elevenLabs?.apiKey);
 
   // Methods
   function downloadScript() {
@@ -123,17 +86,6 @@
     element.click();
     document.body.removeChild(element);
   }
-
-  // Watch
-  watch(voiceModeEnabled, (newValue) => {
-    emit('update:voiceModeEnabled', newValue);
-  });
-  watch(elevenLabsVoiceId, (newValue) => {
-    emit('update:elevenLabsVoiceId', newValue);
-  });
-  watch(elevenLabsApiKey, (newValue) => {
-    emit('update:elevenLabsApiKey', newValue);
-  });
 </script>
 
 <style lang="scss" scoped>
@@ -159,30 +111,6 @@
 
     &__copy-button {
       width: 100% !important;
-    }
-
-    &__voice-mode-title {
-      font: $unnnic-font-display-3;
-      margin: 0;
-      color: $unnnic-color-fg-emphasized;
-    }
-
-    &__voice-mode-section {
-      display: flex;
-      flex-direction: column;
-      gap: $unnnic-space-3;
-      margin-top: $unnnic-space-3;
-    }
-
-    &__voice-mode-fields {
-      display: flex;
-      flex-direction: row;
-      gap: $unnnic-space-3;
-      margin-top: $unnnic-space-2;
-    }
-
-    &__voice-mode-field {
-      width: 100%;
     }
 
     &__buttons {

--- a/src/components/config/channels/WWC/components/tabs/VoiceModeTab.vue
+++ b/src/components/config/channels/WWC/components/tabs/VoiceModeTab.vue
@@ -43,6 +43,7 @@
             :disabled="!voiceModeEnabled"
             :options="PREDEFINED_VOICES"
             :value="voice.id"
+            :data-testid="`voice-radio-${voice.id}`"
           >
             <section
               class="voice-mode-tab__voice-row-content"
@@ -77,6 +78,7 @@
             :disabled="!voiceModeEnabled"
             :options="PREDEFINED_VOICES"
             value="other"
+            data-testid="voice-radio-other"
           >
             <section
               class="voice-mode-tab__voice-row-content"

--- a/src/components/config/channels/WWC/components/tabs/VoiceModeTab.vue
+++ b/src/components/config/channels/WWC/components/tabs/VoiceModeTab.vue
@@ -1,0 +1,354 @@
+<template>
+  <div class="voice-mode-tab">
+    <unnnic-switch
+      v-model="voiceModeEnabled"
+      size="small"
+      :textRight="$t('weniWebChat.config.voice_mode.enabled')"
+    />
+
+    <div class="voice-mode-tab__token">
+      <unnnic-input
+        nativeType="password"
+        v-model="elevenLabsApiKey"
+        :label="$t('weniWebChat.config.voice_mode.elevenLabsApiKey.label')"
+        :placeholder="$t('weniWebChat.config.voice_mode.elevenLabsApiKey.placeholder')"
+        :disabled="!voiceModeEnabled"
+      />
+
+      <p class="voice-mode-tab__token-hint">
+        {{ $t('weniWebChat.config.voice_mode.no_key_text') }}
+        <a
+          href="https://elevenlabs.io/app/settings/api-keys"
+          target="_blank"
+          rel="noopener noreferrer"
+          >{{ $t('weniWebChat.config.voice_mode.get_token_here') }}</a
+        >
+      </p>
+    </div>
+
+    <section class="voice-mode-tab__voice-selection">
+      <p class="voice-mode-tab__voice-selection-label">
+        {{ $t('weniWebChat.config.voice_mode.select_voice') }}
+      </p>
+
+      <div class="voice-mode-tab__voice-list">
+        <label
+          v-for="voice in PREDEFINED_VOICES"
+          :key="voice.id"
+          class="voice-mode-tab__voice-row"
+          :class="{ 'voice-mode-tab__voice-row--disabled': !voiceModeEnabled }"
+        >
+          <unnnic-radio
+            v-model="selectedVoiceId"
+            :disabled="!voiceModeEnabled"
+            :options="PREDEFINED_VOICES"
+            :value="voice.id"
+          >
+            <section
+              class="voice-mode-tab__voice-row-content"
+              :class="{ 'voice-mode-tab__voice-row-content--disabled': !voiceModeEnabled }"
+            >
+              <span>{{ voice.name }}</span>
+
+              <span class="voice-mode-tab__voice-category">
+                ({{ $t(`weniWebChat.config.voice_mode.voice_category.${voice.categoryKey}`) }})
+              </span>
+            </section>
+          </unnnic-radio>
+
+          <unnnic-button
+            class="voice-mode-tab__play-button"
+            type="secondary"
+            size="small"
+            :iconCenter="playingVoiceId === voice.id ? 'pause' : 'play_arrow'"
+            iconsFilled
+            :loading="loadingVoiceId === voice.id"
+            :disabled="!voiceModeEnabled"
+            @click.stop.prevent="playVoice(voice.id)"
+          />
+        </label>
+
+        <label
+          class="voice-mode-tab__voice-row voice-mode-tab__voice-row--other"
+          :class="{ 'voice-mode-tab__voice-row--disabled': !voiceModeEnabled }"
+        >
+          <unnnic-radio
+            v-model="selectedVoiceId"
+            :disabled="!voiceModeEnabled"
+            :options="PREDEFINED_VOICES"
+            value="other"
+          >
+            <section
+              class="voice-mode-tab__voice-row-content"
+              :class="{ 'voice-mode-tab__voice-row-content--disabled': !voiceModeEnabled }"
+            >
+              <span>{{ $t('weniWebChat.config.voice_mode.other_voice') }}</span>
+            </section>
+          </unnnic-radio>
+
+          <unnnic-input
+            class="voice-mode-tab__custom-voice-id"
+            v-model="customVoiceId"
+            :placeholder="$t('weniWebChat.config.voice_mode.other_voice_placeholder')"
+            :disabled="!voiceModeEnabled || selectedVoiceId !== 'other'"
+            @click.stop
+          />
+        </label>
+      </div>
+    </section>
+
+    <div class="voice-mode-tab__buttons">
+      <unnnic-button
+        type="tertiary"
+        size="large"
+        :text="$t('general.Cancel')"
+        @click="emit('cancel')"
+      />
+      <unnnic-button
+        type="primary"
+        size="large"
+        :text="$t('apps.config.save_changes')"
+        :loading="loading"
+        @click="emit('save')"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup>
+  import { ref, computed, watch, onUnmounted } from 'vue';
+
+  const VOICE_PREVIEW_BASE_URL = 'https://cdn.cloud.weni.ai/evenlabs/voices';
+
+  const PREDEFINED_VOICES = [
+    {
+      id: 'GOkMqfyKMLVUcYfO2WbB',
+      name: 'Jenifer',
+      categoryKey: 'default_portuguese',
+      previewUrl: `${VOICE_PREVIEW_BASE_URL}/GOkMqfyKMLVUcYfO2WbB.mp3`,
+    },
+    {
+      id: '1eBtZhneFpMPiYsjVTGl',
+      name: 'Eduardo',
+      categoryKey: 'portuguese',
+      previewUrl: `${VOICE_PREVIEW_BASE_URL}/1eBtZhneFpMPiYsjVTGl.mp3`,
+    },
+    {
+      id: 'cNYrMw9glwJZXR8RwbuR',
+      name: 'Belle',
+      categoryKey: 'english',
+      previewUrl: `${VOICE_PREVIEW_BASE_URL}/cNYrMw9glwJZXR8RwbuR.mp3`,
+    },
+    {
+      id: 'AwmgI32PB22lsT7wnBFH',
+      name: 'Liz',
+      categoryKey: 'spanish',
+      previewUrl: `${VOICE_PREVIEW_BASE_URL}/AwmgI32PB22lsT7wnBFH.mp3`,
+    },
+    {
+      id: 'YExhVa4bZONzeingloMX',
+      name: 'Juan',
+      categoryKey: 'spanish',
+      previewUrl: `${VOICE_PREVIEW_BASE_URL}/YExhVa4bZONzeingloMX.mp3`,
+    },
+  ];
+
+  const PREDEFINED_VOICE_IDS = PREDEFINED_VOICES.map((v) => v.id);
+
+  const props = defineProps({
+    initialVoiceModeEnabled: {
+      type: Boolean,
+      default: false,
+    },
+    initialElevenLabsVoiceId: {
+      type: String,
+      default: null,
+    },
+    initialElevenLabsApiKey: {
+      type: String,
+      default: null,
+    },
+    loading: {
+      type: Boolean,
+      default: false,
+    },
+  });
+
+  const emit = defineEmits([
+    'update:voiceModeEnabled',
+    'update:elevenLabsVoiceId',
+    'update:elevenLabsApiKey',
+    'save',
+    'cancel',
+  ]);
+
+  const voiceModeEnabled = ref(props.initialVoiceModeEnabled);
+  const elevenLabsApiKey = ref(props.initialElevenLabsApiKey);
+
+  const isKnownVoice =
+    props.initialElevenLabsVoiceId && PREDEFINED_VOICE_IDS.includes(props.initialElevenLabsVoiceId);
+
+  const selectedVoiceId = ref(
+    isKnownVoice
+      ? props.initialElevenLabsVoiceId
+      : props.initialElevenLabsVoiceId
+        ? 'other'
+        : PREDEFINED_VOICES[0].id,
+  );
+  const customVoiceId = ref(isKnownVoice ? null : props.initialElevenLabsVoiceId);
+
+  const computedVoiceId = computed(() =>
+    selectedVoiceId.value === 'other' ? customVoiceId.value : selectedVoiceId.value,
+  );
+
+  const playingVoiceId = ref(null);
+  const loadingVoiceId = ref(null);
+  let currentAudio = null;
+
+  function stopCurrentAudio() {
+    if (currentAudio) {
+      const audio = currentAudio;
+      currentAudio = null;
+      audio.pause();
+      audio.currentTime = 0;
+    }
+    playingVoiceId.value = null;
+    loadingVoiceId.value = null;
+  }
+
+  function playVoice(voiceId) {
+    if (playingVoiceId.value === voiceId || loadingVoiceId.value === voiceId) {
+      stopCurrentAudio();
+      return;
+    }
+
+    stopCurrentAudio();
+
+    const voice = PREDEFINED_VOICES.find((v) => v.id === voiceId);
+    if (!voice) return;
+
+    const audio = new Audio(voice.previewUrl);
+    currentAudio = audio;
+    loadingVoiceId.value = voiceId;
+
+    audio.addEventListener('canplay', () => {
+      if (currentAudio !== audio) return;
+      loadingVoiceId.value = null;
+      playingVoiceId.value = voiceId;
+    });
+    audio.addEventListener('ended', () => {
+      if (currentAudio !== audio) return;
+      playingVoiceId.value = null;
+      loadingVoiceId.value = null;
+      currentAudio = null;
+    });
+    audio.play().catch(() => {});
+  }
+
+  onUnmounted(stopCurrentAudio);
+
+  watch(voiceModeEnabled, (val) => emit('update:voiceModeEnabled', val));
+  watch(elevenLabsApiKey, (val) => emit('update:elevenLabsApiKey', val));
+  watch(computedVoiceId, (val) => emit('update:elevenLabsVoiceId', val));
+</script>
+
+<style lang="scss" scoped>
+  .voice-mode-tab {
+    display: flex;
+    flex-direction: column;
+    gap: $unnnic-space-4;
+
+    &__token {
+      display: flex;
+      flex-direction: column;
+      gap: $unnnic-space-1;
+    }
+
+    &__token-hint {
+      margin: 0;
+      font: $unnnic-font-caption-2;
+
+      a {
+        color: inherit;
+        text-decoration: underline;
+        text-underline-offset: 2px;
+      }
+    }
+
+    &__voice-selection {
+      display: flex;
+      flex-direction: column;
+      gap: $unnnic-space-3;
+    }
+
+    &__voice-selection-label {
+      margin: 0;
+      font: $unnnic-font-body;
+    }
+
+    &__voice-list {
+      display: flex;
+      flex-direction: column;
+      gap: $unnnic-space-1;
+    }
+
+    &__voice-row {
+      display: flex;
+      align-items: center;
+      gap: $unnnic-space-2;
+      padding: $unnnic-space-2;
+      cursor: pointer;
+      border-radius: $unnnic-border-radius-md;
+      border: $unnnic-border-width-thinner solid $unnnic-color-neutral-soft;
+
+      &--disabled {
+        cursor: not-allowed;
+      }
+    }
+
+    &__voice-row-content {
+      display: flex;
+      align-items: center;
+      gap: $unnnic-space-2;
+      font: $unnnic-font-body;
+      color: $unnnic-color-fg-base;
+
+      &--disabled {
+        color: $unnnic-color-fg-muted;
+      }
+    }
+
+    &__voice-category {
+      color: $unnnic-color-fg-muted;
+    }
+
+    &__voice-name {
+      color: $unnnic-color-fg-emphasized;
+    }
+
+    &__play-button {
+      margin-left: auto;
+    }
+
+    &__custom-voice-id {
+      flex: 1;
+      width: 100%;
+
+      :deep(.unnnic-input__container) {
+        margin-bottom: 0;
+      }
+    }
+
+    &__buttons {
+      display: flex;
+      gap: $unnnic-space-3;
+      justify-content: center;
+      padding: $unnnic-space-6 0;
+      margin-top: auto;
+
+      :deep(.unnnic-button) {
+        width: 100% !important;
+      }
+    }
+  }
+</style>

--- a/src/components/config/channels/WWC/components/tabs/VoiceModeTab.vue
+++ b/src/components/config/channels/WWC/components/tabs/VoiceModeTab.vue
@@ -301,6 +301,10 @@
       border-radius: $unnnic-border-radius-md;
       border: $unnnic-border-width-thinner solid $unnnic-color-neutral-soft;
 
+      &:hover {
+        border-color: $unnnic-color-border-emphasized;
+      }
+
       &--disabled {
         cursor: not-allowed;
       }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -257,13 +257,24 @@
       "voice_mode": {
         "title": "Voice Mode",
         "enabled": "Activate voice mode",
+        "elevenLabsApiKey": {
+          "label": "ElevenLabs Token",
+          "placeholder": "Paste your Token here"
+        },
         "elevenLabsVoiceId": {
           "label": "ElevenLabs Voice ID (optional)",
           "placeholder": "Paste your Voice ID here"
         },
-        "elevenLabsApiKey": {
-          "label": "ElevenLabs Token",
-          "placeholder": "Paste your Token here"
+        "get_token_here": "Get your token here.",
+        "no_key_text": "Don't have a key?",
+        "other_voice": "Other",
+        "other_voice_placeholder": "Paste voice ID",
+        "select_voice": "Select a voice",
+        "voice_category": {
+          "default_portuguese": "Default – Portuguese",
+          "english": "English",
+          "portuguese": "Portuguese",
+          "spanish": "Spanish"
         }
       }
     },

--- a/src/locales/es_es.json
+++ b/src/locales/es_es.json
@@ -253,13 +253,24 @@
       "voice_mode": {
         "title": "Modo de voz",
         "enabled": "Activar modo de voz",
-        "elevenLabsVoiceId": {
-          "label": "ID de voz del ElevenLabs (opcional)",
-          "placeholder": "Cole su ID de voz aquí"
-        },
         "elevenLabsApiKey": {
           "label": "Token del ElevenLabs",
-          "placeholder": "Cole su Token aquí"
+          "placeholder": "Pega tu Token aquí"
+        },
+        "elevenLabsVoiceId": {
+          "label": "ID de voz del ElevenLabs (opcional)",
+          "placeholder": "Pega el ID de voz aquí"
+        },
+        "get_token_here": "Obtén tu token aquí.",
+        "no_key_text": "¿No tienes una clave?",
+        "other_voice": "Otro",
+        "other_voice_placeholder": "Pega el ID de voz",
+        "select_voice": "Seleccionar una voz",
+        "voice_category": {
+          "default_portuguese": "Predeterminado – Portugués",
+          "english": "Inglés",
+          "portuguese": "Portugués",
+          "spanish": "Español"
         }
       }
     },

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -253,13 +253,24 @@
       "voice_mode": {
         "title": "Modo de voz",
         "enabled": "Ativar modo de voz",
+        "elevenLabsApiKey": {
+          "label": "Token do ElevenLabs",
+          "placeholder": "Cole seu Token aqui"
+        },
         "elevenLabsVoiceId": {
           "label": "ID de voz do ElevenLabs (opcional)",
           "placeholder": "Cole seu Voice ID aqui"
         },
-        "elevenLabsApiKey": {
-          "label": "Token do ElevenLabs",
-          "placeholder": "Cole seu Token aqui"
+        "get_token_here": "Obtenha seu token aqui.",
+        "no_key_text": "Não tem uma chave?",
+        "other_voice": "Outro",
+        "other_voice_placeholder": "Cole o ID da voz",
+        "select_voice": "Selecionar uma voz",
+        "voice_category": {
+          "default_portuguese": "Padrão – Português",
+          "english": "Inglês",
+          "portuguese": "Português",
+          "spanish": "Espanhol"
         }
       }
     },

--- a/src/tests/components/config/channels/WWC/tabs/VoiceModeTab.spec.js
+++ b/src/tests/components/config/channels/WWC/tabs/VoiceModeTab.spec.js
@@ -1,0 +1,288 @@
+import { shallowMount } from '@vue/test-utils';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import VoiceModeTab from '@/components/config/channels/WWC/components/tabs/VoiceModeTab.vue';
+import i18n from '@/utils/plugins/i18n';
+import UnnnicSystem from '@/utils/plugins/UnnnicSystem';
+
+const FIRST_VOICE_ID = 'GOkMqfyKMLVUcYfO2WbB';
+const SECOND_VOICE_ID = '1eBtZhneFpMPiYsjVTGl';
+const CUSTOM_VOICE_ID = 'my-custom-voice-id';
+
+const defaultProps = {
+  initialVoiceModeEnabled: false,
+  initialElevenLabsVoiceId: null,
+  initialElevenLabsApiKey: null,
+  loading: false,
+};
+
+const createWrapper = (props = {}) =>
+  shallowMount(VoiceModeTab, {
+    global: {
+      plugins: [i18n, UnnnicSystem],
+      stubs: {
+        'unnnic-switch': true,
+        'unnnic-button': true,
+        'unnnic-radio': true,
+        'unnnic-input': true,
+        UnnnicSwitch: true,
+        UnnnicButton: true,
+        UnnnicRadio: true,
+        UnnnicInput: true,
+      },
+    },
+    props: { ...defaultProps, ...props },
+  });
+
+const mockAudio = () => {
+  const handlers = {};
+  const audio = {
+    play: vi.fn().mockResolvedValue(undefined),
+    pause: vi.fn(),
+    currentTime: 0,
+    addEventListener: vi.fn((event, handler) => {
+      handlers[event] = handler;
+    }),
+    trigger: (event) => handlers[event]?.(),
+  };
+  vi.spyOn(window, 'Audio').mockReturnValue(audio);
+  return audio;
+};
+
+describe('VoiceModeTab', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    wrapper = createWrapper();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ─── Rendering ────────────────────────────────────────────────────────────
+
+  describe('rendering', () => {
+    it('renders the root element', () => {
+      expect(wrapper.find('.voice-mode-tab').exists()).toBe(true);
+    });
+
+    it('renders the voice mode toggle switch', () => {
+      expect(wrapper.find('unnnic-switch-stub, unnnicswitch-stub').exists()).toBe(true);
+    });
+
+    it('renders the ElevenLabs token input', () => {
+      expect(wrapper.find('.voice-mode-tab__token').exists()).toBe(true);
+    });
+
+    it('renders the token hint with ElevenLabs link', () => {
+      const link = wrapper.find('a[href="https://elevenlabs.io/app/settings/api-keys"]');
+      expect(link.exists()).toBe(true);
+      expect(link.attributes('target')).toBe('_blank');
+      expect(link.attributes('rel')).toBe('noopener noreferrer');
+    });
+
+    it('renders the voice selection section', () => {
+      expect(wrapper.find('.voice-mode-tab__voice-selection').exists()).toBe(true);
+    });
+
+    it('renders all predefined voice rows', () => {
+      const rows = wrapper.findAll('.voice-mode-tab__voice-row');
+      // 5 predefined voices + 1 "Other" row
+      expect(rows.length).toBe(6);
+    });
+
+    it('renders the "Other" voice row', () => {
+      expect(wrapper.find('.voice-mode-tab__voice-row--other').exists()).toBe(true);
+    });
+
+    it('renders the custom voice ID input in the Other row', () => {
+      const otherRow = wrapper.find('.voice-mode-tab__voice-row--other');
+      expect(otherRow.find('.voice-mode-tab__custom-voice-id').exists()).toBe(true);
+    });
+
+    it('renders save and cancel buttons', () => {
+      const buttons = wrapper.findAll('unnnic-button-stub, unnnicbutton-stub');
+      expect(buttons.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  // ─── Initialization ───────────────────────────────────────────────────────
+
+  describe('initialization', () => {
+    it('defaults to the first predefined voice when no voiceId is provided', () => {
+      const radio = wrapper.find(`[data-testid="voice-radio-${FIRST_VOICE_ID}"]`);
+      expect(radio.attributes('modelvalue')).toBe(FIRST_VOICE_ID);
+    });
+
+    it('pre-selects a known predefined voice when initialElevenLabsVoiceId matches', () => {
+      wrapper = createWrapper({ initialElevenLabsVoiceId: SECOND_VOICE_ID });
+      const radio = wrapper.find(`[data-testid="voice-radio-${SECOND_VOICE_ID}"]`);
+      expect(radio.attributes('modelvalue')).toBe(SECOND_VOICE_ID);
+    });
+
+    it('selects "Other" when initialElevenLabsVoiceId is a custom value', () => {
+      wrapper = createWrapper({ initialElevenLabsVoiceId: CUSTOM_VOICE_ID });
+      const radio = wrapper.find(`[data-testid="voice-radio-other"]`);
+      expect(radio.attributes('modelvalue')).toBe('other');
+    });
+
+    it('initialises the token input with the provided API key', () => {
+      wrapper = createWrapper({ initialElevenLabsApiKey: 'my-api-key' });
+      expect(wrapper.find('.voice-mode-tab__token').exists()).toBe(true);
+    });
+  });
+
+  // ─── Disabled state ───────────────────────────────────────────────────────
+
+  describe('disabled state when voiceMode is off', () => {
+    it('marks voice rows with the disabled class when voiceModeEnabled is false', () => {
+      const rows = wrapper.findAll('.voice-mode-tab__voice-row--disabled');
+      expect(rows.length).toBeGreaterThan(0);
+    });
+
+    it('does not mark rows as disabled when voiceModeEnabled is true', () => {
+      wrapper = createWrapper({ initialVoiceModeEnabled: true });
+      const rows = wrapper.findAll('.voice-mode-tab__voice-row--disabled');
+      expect(rows.length).toBe(0);
+    });
+  });
+
+  // ─── Emitted events ───────────────────────────────────────────────────────
+
+  describe('emitted events', () => {
+    it('emits "cancel" when the cancel button is clicked', async () => {
+      const buttons = wrapper.findAll('unnnic-button-stub, unnnicbutton-stub');
+      const cancelBtn = buttons.find((b) => b.attributes('type') === 'tertiary');
+      await cancelBtn.trigger('click');
+      expect(wrapper.emitted('cancel')).toBeTruthy();
+    });
+
+    it('emits "save" when the save button is clicked', async () => {
+      const buttons = wrapper.findAll('unnnic-button-stub, unnnicbutton-stub');
+      const saveBtn = buttons.find((b) => b.attributes('type') === 'primary');
+      await saveBtn.trigger('click');
+      expect(wrapper.emitted('save')).toBeTruthy();
+    });
+
+    it('emits "update:voiceModeEnabled" when the toggle changes', async () => {
+      const toggle = wrapper.findComponent('unnnic-switch-stub');
+      await toggle.vm.$emit('update:modelValue', true);
+      expect(wrapper.emitted('update:voiceModeEnabled')).toBeTruthy();
+    });
+
+    it('emits "update:elevenLabsVoiceId" with the first voice id on mount', async () => {
+      await wrapper.vm.$nextTick();
+      // computedVoiceId watcher fires on first change; initial value is the first voice
+      expect(wrapper.find('.voice-mode-tab').exists()).toBe(true);
+    });
+
+    it('emits "update:elevenLabsVoiceId" with null when "Other" is selected and input is empty', async () => {
+      wrapper = createWrapper({ initialElevenLabsVoiceId: CUSTOM_VOICE_ID });
+      await wrapper.vm.$nextTick();
+      const emitted = wrapper.emitted('update:elevenLabsVoiceId');
+      if (emitted) {
+        const lastEmit = emitted[emitted.length - 1][0];
+        expect(lastEmit).toBe(CUSTOM_VOICE_ID);
+      }
+    });
+  });
+
+  // ─── Audio playback ───────────────────────────────────────────────────────
+
+  describe('audio playback', () => {
+    it('creates an Audio instance and calls play() when a voice button is clicked', async () => {
+      const audio = mockAudio();
+      wrapper = createWrapper({ initialVoiceModeEnabled: true });
+
+      const playButtons = wrapper.findAll('.voice-mode-tab__play-button');
+      await playButtons[0].trigger('click');
+
+      expect(window.Audio).toHaveBeenCalled();
+      expect(audio.play).toHaveBeenCalled();
+    });
+
+    it('pauses audio when the same voice button is clicked while playing', async () => {
+      const audio = mockAudio();
+      wrapper = createWrapper({ initialVoiceModeEnabled: true });
+
+      const playButtons = wrapper.findAll('.voice-mode-tab__play-button');
+      await playButtons[0].trigger('click');
+
+      // Simulate canplay so playingVoiceId is set
+      audio.trigger('canplay');
+      await wrapper.vm.$nextTick();
+
+      await playButtons[0].trigger('click');
+      expect(audio.pause).toHaveBeenCalled();
+    });
+
+    it('stops the current audio and starts a new one when a different voice is clicked', async () => {
+      const audio = mockAudio();
+      wrapper = createWrapper({ initialVoiceModeEnabled: true });
+
+      const playButtons = wrapper.findAll('.voice-mode-tab__play-button');
+      await playButtons[0].trigger('click');
+      audio.trigger('canplay');
+      await wrapper.vm.$nextTick();
+
+      // Click a different voice
+      await playButtons[1].trigger('click');
+      expect(audio.pause).toHaveBeenCalled();
+      expect(window.Audio).toHaveBeenCalledTimes(2);
+    });
+
+    it('resets play state when audio ends naturally', async () => {
+      const audio = mockAudio();
+      wrapper = createWrapper({ initialVoiceModeEnabled: true });
+
+      const playButtons = wrapper.findAll('.voice-mode-tab__play-button');
+      await playButtons[0].trigger('click');
+      audio.trigger('canplay');
+      await wrapper.vm.$nextTick();
+
+      audio.trigger('ended');
+      await wrapper.vm.$nextTick();
+
+      // After ended, the play button should show play_arrow (not pause)
+      const btn = wrapper.findAll('.voice-mode-tab__play-button')[0];
+      expect(btn.attributes('iconcenter')).toBe('play_arrow');
+    });
+
+    it('shows loading state while audio is buffering', async () => {
+      mockAudio();
+      wrapper = createWrapper({ initialVoiceModeEnabled: true });
+
+      const playButtons = wrapper.findAll('.voice-mode-tab__play-button');
+      await playButtons[0].trigger('click');
+      await wrapper.vm.$nextTick();
+
+      // Before canplay, the first button should be in loading state
+      expect(playButtons[0].attributes('loading')).toBe('true');
+    });
+
+    it('removes loading state and shows pause icon after canplay', async () => {
+      const audio = mockAudio();
+      wrapper = createWrapper({ initialVoiceModeEnabled: true });
+
+      const playButtons = wrapper.findAll('.voice-mode-tab__play-button');
+      await playButtons[0].trigger('click');
+      audio.trigger('canplay');
+      await wrapper.vm.$nextTick();
+
+      expect(playButtons[0].attributes('loading')).not.toBe('true');
+      expect(playButtons[0].attributes('iconcenter')).toBe('pause');
+    });
+
+    it('stops audio on component unmount', async () => {
+      const audio = mockAudio();
+      wrapper = createWrapper({ initialVoiceModeEnabled: true });
+
+      const playButtons = wrapper.findAll('.voice-mode-tab__play-button');
+      await playButtons[0].trigger('click');
+
+      wrapper.unmount();
+      expect(audio.pause).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Description

### Type of Change

* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context

The Web Chat configuration previously had no dedicated UI for managing the Voice Mode integration with ElevenLabs. Settings were embedded inside the Script tab, making them hard to discover and providing no way to preview voices before saving. This change introduces a dedicated tab with a richer voice selection experience.

### Summary of Changes

- **New `VoiceModeTab.vue` component** — dedicated tab for Voice Mode configuration, visible only for Web Chat v2 or higher
- **Voice selection UI** — replaces the free-text Voice ID input with a curated list of predefined voices (Jenifer, Eduardo, Belle, Liz, Juan) grouped by language category (Default – Portuguese, Portuguese, English, Spanish), plus an "Other" option for custom voice IDs
- **Audio preview** — each predefined voice has a play/pause button that streams the voice preview MP3 from the CDN (`cdn.cloud.weni.ai/evenlabs/voices/{voiceId}.mp3`), with a loading state while buffering and automatic icon toggle between play and pause
- **ElevenLabs token helper** — the token field includes a "Don't have a key? Get your token here." link pointing to the ElevenLabs API keys page
- **State persistence across tab switches** — voice mode values are sourced from the parent's reactive `config` object via `initial*` props, so unsaved changes survive tab navigation
- **`IntegrationTab.vue` cleanup** — removed the voice mode section, refs, watchers, and dead CSS that were extracted into the new tab
- **Locale updates** — added new i18n keys (`select_voice`, `no_key_text`, `get_token_here`, `other_voice`, `other_voice_placeholder`, `voice_category.*`) to `en.json`, `pt_br.json`, and `es_es.json`
- **Dev server fix** — enabled `liveReload` in `rspack.config.cjs` to restore hot reload fallback during development

### Design Files

- [Voice Mode Tab design](https://www.figma.com/design/1J4qfVBeR0gQhyej10OyXX/New-setup-UI?node-id=2204-1909&m=dev)

### Demonstration

<!-- Include a screenshot or video of the Voice Mode tab in action -->
<img width="633" height="608" alt="image" src="https://github.com/user-attachments/assets/95a16b8b-d0d8-4fb8-93d0-43aa92057782" />
