### PR TITLE
✨ Open Config Drawer Directly Via URL

### DIFF
--- a/src/components/AppGrid/index.vue
+++ b/src/components/AppGrid/index.vue
@@ -275,8 +275,10 @@
 
         if (this.type === 'add' && app.code !== 'email' && app.code !== 'gmail') {
           this.openAppDetails(app.code);
+        } else if (this.type === 'edit') {
+          this.$router.push(`/apps/my/configured/${app.code}/${app.uuid}`);
         } else {
-          this.$refs.configModal.openModal({ app, isConfigured: this.type === 'edit' });
+          this.$refs.configModal.openModal({ app, isConfigured: false });
         }
       },
       appRatingAverage(app) {

--- a/src/components/config/ConfigModal.vue
+++ b/src/components/config/ConfigModal.vue
@@ -87,6 +87,7 @@
         }),
       };
     },
+    emits: ['close'],
     methods: {
       closeModal() {
         if (this.needConfirmation) {
@@ -94,6 +95,7 @@
           return;
         }
         this.show = false;
+        this.$emit('close');
       },
       openModal({ app, isConfigured }) {
         this.type = app.code;
@@ -111,6 +113,7 @@
         this.needConfirmation = false;
         this.showConfirmationModal = false;
         this.show = false;
+        this.$emit('close');
       },
     },
     computed: {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -20,6 +20,11 @@ const routes = [
         component: () => import('@/views/MyApps/index.vue'),
       },
       {
+        name: 'App Config Direct',
+        path: 'my/configured/:appCode/:appUuid',
+        component: () => import('@/views/MyApps/index.vue'),
+      },
+      {
         name: 'Other Apps',
         path: 'other-apps',
         component: () => import('@/views/OtherApps/index.vue'),

--- a/src/tests/components/AppGrid.spec.js
+++ b/src/tests/components/AppGrid.spec.js
@@ -85,5 +85,71 @@ describe('AppGrid', () => {
       await wrapper.vm.openAppDetails('1234');
       expect(pushMock).toHaveBeenCalledWith('/1234/details');
     });
+
+    describe('openAppModal', () => {
+      const configuredApp = {
+        uuid: 'app-uuid-123',
+        code: 'wwc',
+        name: 'Weni Web Chat',
+        generic: false,
+        icon: null,
+        summary: 'weniWebChat.data.summary',
+        config: {},
+        rating: { average: null },
+        comments_count: 0,
+      };
+
+      const mountForOpenAppModal = (type) =>
+        mount(AppGrid, {
+          props: { section: 'configured', type, apps: [configuredApp] },
+          global: {
+            plugins: [pinia, i18n],
+            mocks: {
+              $router: { push: pushMock },
+              $t: (e) => e,
+            },
+          },
+        });
+
+      it('pushes route to configured app URL when type is "edit"', async () => {
+        pushMock.mockClear();
+        const w = mountForOpenAppModal('edit');
+        await w.vm.openAppModal(configuredApp);
+        expect(pushMock).toHaveBeenCalledWith(
+          `/apps/my/configured/${configuredApp.code}/${configuredApp.uuid}`,
+        );
+      });
+
+      it('calls configModal.openModal when type is "config"', async () => {
+        pushMock.mockClear();
+        const w = mountForOpenAppModal('config');
+        await w.vm.$nextTick();
+
+        const openModalSpy = vi
+          .spyOn(w.vm.$refs.configModal, 'openModal')
+          .mockImplementation(() => {});
+
+        await w.vm.openAppModal(configuredApp);
+
+        expect(openModalSpy).toHaveBeenCalledWith({ app: configuredApp, isConfigured: false });
+        expect(pushMock).not.toHaveBeenCalledWith(
+          expect.stringContaining('/apps/my/configured/'),
+        );
+      });
+
+      it('does nothing when type is "add" and app is generic', async () => {
+        pushMock.mockClear();
+        const genericApp = { ...configuredApp, generic: true };
+        const w = mount(AppGrid, {
+          props: { section: 'configured', type: 'add', apps: [genericApp] },
+          global: {
+            plugins: [pinia, i18n],
+            mocks: { $router: { push: pushMock }, $t: (e) => e },
+          },
+        });
+        await w.vm.openAppModal(genericApp);
+        expect(pushMock).not.toHaveBeenCalled();
+      });
+    });
   });
 });

--- a/src/tests/components/config/ConfigModal.spec.js
+++ b/src/tests/components/config/ConfigModal.spec.js
@@ -99,4 +99,25 @@ describe('ConfigModal.vue', () => {
     await wrapper.vm.setConfirmation(true);
     expect(wrapper.vm.needConfirmation).toBe(true);
   });
+
+  describe('close event', () => {
+    it('emits close when closeModal is called and needConfirmation is false', async () => {
+      wrapper.vm.needConfirmation = false;
+      await wrapper.vm.closeModal();
+      expect(wrapper.emitted('close')).toHaveLength(1);
+    });
+
+    it('does not emit close when closeModal is called and needConfirmation is true', async () => {
+      wrapper.vm.needConfirmation = true;
+      await wrapper.vm.closeModal();
+      expect(wrapper.emitted('close')).toBeFalsy();
+    });
+
+    it('emits close when confirmClose is called', async () => {
+      wrapper.vm.needConfirmation = true;
+      await wrapper.vm.closeModal();
+      await wrapper.vm.confirmClose();
+      expect(wrapper.emitted('close')).toHaveLength(1);
+    });
+  });
 });

--- a/src/tests/utils/moduleFederation.spec.js
+++ b/src/tests/utils/moduleFederation.spec.js
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/utils/env', () => ({ default: vi.fn() }));
+
+async function loadModule(publicPathUrl, origin = 'http://localhost') {
+  vi.resetModules();
+
+  const getEnv = (await import('@/utils/env')).default;
+  getEnv.mockReturnValue(publicPathUrl);
+
+  Object.defineProperty(window, 'location', {
+    value: { origin },
+    writable: true,
+  });
+
+  const { isFederatedModule } = await import('@/utils/moduleFederation');
+  return isFederatedModule;
+}
+
+describe('isFederatedModule', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns false when PUBLIC_PATH_URL is a relative path "/"', async () => {
+    const result = await loadModule('/');
+    expect(result).toBe(false);
+  });
+
+  it('returns false when PUBLIC_PATH_URL is empty', async () => {
+    const result = await loadModule('');
+    expect(result).toBe(false);
+  });
+
+  it('returns false when PUBLIC_PATH_URL is undefined', async () => {
+    const result = await loadModule(undefined);
+    expect(result).toBe(false);
+  });
+
+  it('returns false when PUBLIC_PATH_URL matches the current origin', async () => {
+    const result = await loadModule('http://localhost:5174/', 'http://localhost:5174');
+    expect(result).toBe(false);
+  });
+
+  it('returns true when PUBLIC_PATH_URL is a different absolute URL', async () => {
+    const result = await loadModule(
+      'https://integrations.stg.cloud.weni.ai/',
+      'http://localhost:5174',
+    );
+    expect(result).toBe(true);
+  });
+
+  it('ignores trailing slashes when comparing origins', async () => {
+    const result = await loadModule(
+      'https://integrations.stg.cloud.weni.ai',
+      'https://integrations.stg.cloud.weni.ai',
+    );
+    expect(result).toBe(false);
+  });
+});

--- a/src/tests/views/MyApps.spec.js
+++ b/src/tests/views/MyApps.spec.js
@@ -3,6 +3,23 @@ import { createTestingPinia } from '@pinia/testing';
 import MyApps from '../../views/MyApps/index.vue';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import i18n from '@/utils/plugins/i18n';
+import { app_type } from '@/stores/modules/appType/appType.store';
+
+const mockApp = {
+  uuid: 'app-uuid-123',
+  code: 'wwc',
+  name: 'Weni Web Chat',
+  generic: false,
+  icon: null,
+  summary: 'weniWebChat.data.summary',
+  config: { title: 'My Chat' },
+  rating: { average: null },
+  comments_count: 0,
+};
+
+const mockRoute = (params = {}) => ({ params });
+const mockRouter = () => ({ replace: vi.fn(), back: vi.fn(), push: vi.fn() });
+
 describe('MyApps', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -91,15 +108,190 @@ describe('MyApps', () => {
         global: {
           plugins: [createTestingPinia({ createSpy: vi.fn }), i18n],
           mocks: {
-            $router: {
-              replace: replaceMock,
-            },
+            $router: { replace: replaceMock },
+            $route: mockRoute(),
           },
         },
       });
 
       wrapper.vm.navigateToDiscovery();
       expect(replaceMock).toHaveBeenCalledWith('/apps/discovery');
+    });
+
+    describe('openConfigFromRoute', () => {
+      it('calls directConfigModal.openModal via $nextTick', async () => {
+        const wrapper = mount(MyApps, {
+          global: {
+            plugins: [createTestingPinia({ createSpy: vi.fn }), i18n],
+            mocks: { $router: mockRouter(), $route: mockRoute() },
+          },
+        });
+        await wrapper.vm.$nextTick();
+
+        const openModalSpy = vi
+          .spyOn(wrapper.vm.$refs.directConfigModal, 'openModal')
+          .mockImplementation(() => {});
+
+        wrapper.vm.openConfigFromRoute(mockApp);
+        await wrapper.vm.$nextTick();
+
+        expect(openModalSpy).toHaveBeenCalledWith({ app: mockApp, isConfigured: true });
+      });
+
+      it('does not throw if directConfigModal ref is unavailable', async () => {
+        const wrapper = mount(MyApps, {
+          global: {
+            plugins: [createTestingPinia({ createSpy: vi.fn }), i18n],
+            mocks: { $router: mockRouter(), $route: mockRoute() },
+          },
+        });
+        wrapper.vm.$refs.directConfigModal = undefined;
+        expect(() => wrapper.vm.openConfigFromRoute(mockApp)).not.toThrow();
+      });
+    });
+
+    describe('fetchAppFromRoute', () => {
+      const mountForFetch = (params = { appCode: 'wwc', appUuid: 'app-uuid-123' }) => {
+        const pinia = createTestingPinia({ createSpy: vi.fn });
+        const wrapper = mount(MyApps, {
+          global: {
+            plugins: [pinia, i18n],
+            mocks: { $router: mockRouter(), $route: mockRoute(params) },
+          },
+        });
+        const store = app_type();
+        // Reset state left by the immediate watcher that fired during mount
+        wrapper.vm.isFetchingApp = false;
+        store.getApp.mockClear();
+        return { wrapper, store };
+      };
+
+      it('calls getApp with appCode and appUuid from route params', async () => {
+        const { wrapper, store } = mountForFetch();
+        store.$patch({ currentApp: mockApp, errorCurrentApp: null });
+
+        const openModalSpy = vi
+          .spyOn(wrapper.vm.$refs.directConfigModal, 'openModal')
+          .mockImplementation(() => {});
+
+        await wrapper.vm.fetchAppFromRoute();
+
+        expect(store.getApp).toHaveBeenCalledWith({ code: 'wwc', appUuid: 'app-uuid-123' });
+        expect(openModalSpy).toHaveBeenCalledWith({ app: mockApp, isConfigured: true });
+      });
+
+      it('shows error alert and does not open modal when getApp fails', async () => {
+        const { wrapper, store } = mountForFetch();
+        store.$patch({ currentApp: null, errorCurrentApp: new Error('Not found') });
+
+        const openModalSpy = vi
+          .spyOn(wrapper.vm.$refs.directConfigModal, 'openModal')
+          .mockImplementation(() => {});
+
+        await wrapper.vm.fetchAppFromRoute();
+
+        expect(openModalSpy).not.toHaveBeenCalled();
+      });
+
+      it('guards against duplicate concurrent calls with isFetchingApp', async () => {
+        const { wrapper, store } = mountForFetch();
+        store.$patch({ errorCurrentApp: null });
+
+        const firstCall = wrapper.vm.fetchAppFromRoute();
+        const secondCall = wrapper.vm.fetchAppFromRoute();
+        await Promise.all([firstCall, secondCall]);
+
+        expect(store.getApp).toHaveBeenCalledTimes(1);
+      });
+
+      it('does nothing when appCode or appUuid are missing', async () => {
+        const { wrapper, store } = mountForFetch({});
+
+        await wrapper.vm.fetchAppFromRoute();
+
+        expect(store.getApp).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('onDirectConfigModalClose', () => {
+      it('calls $router.back() when window.history.state.back is set', () => {
+        const router = mockRouter();
+        const wrapper = mount(MyApps, {
+          global: {
+            plugins: [createTestingPinia({ createSpy: vi.fn }), i18n],
+            mocks: { $router: router, $route: mockRoute() },
+          },
+        });
+
+        window.history.pushState({ back: '/apps/my' }, '');
+        wrapper.vm.onDirectConfigModalClose();
+        expect(router.back).toHaveBeenCalled();
+        expect(router.replace).not.toHaveBeenCalled();
+      });
+
+      it('calls $router.replace("/apps/my") when there is no history.back', () => {
+        const router = mockRouter();
+        const wrapper = mount(MyApps, {
+          global: {
+            plugins: [createTestingPinia({ createSpy: vi.fn }), i18n],
+            mocks: { $router: router, $route: mockRoute() },
+          },
+        });
+
+        window.history.replaceState({}, '');
+        wrapper.vm.onDirectConfigModalClose();
+        expect(router.replace).toHaveBeenCalledWith('/apps/my');
+        expect(router.back).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('route watcher', () => {
+      it('calls openConfigFromRoute when appUuid is in route and app is in configuredApps', async () => {
+        const openSpy = vi
+          .spyOn(MyApps.methods, 'openConfigFromRoute')
+          .mockImplementation(() => {});
+
+        const pinia = createTestingPinia({
+          createSpy: vi.fn,
+          initialState: { myApps: { configuredApps: [mockApp] } },
+        });
+
+        mount(MyApps, {
+          global: {
+            plugins: [pinia, i18n],
+            mocks: {
+              $router: mockRouter(),
+              $route: mockRoute({ appUuid: mockApp.uuid, appCode: mockApp.code }),
+              $t: (msg) => msg,
+            },
+          },
+        });
+
+        await Promise.resolve();
+        expect(openSpy).toHaveBeenCalledWith(mockApp);
+        openSpy.mockRestore();
+      });
+
+      it('calls fetchAppFromRoute when appUuid is in route but app is not in configuredApps', async () => {
+        const fetchSpy = vi
+          .spyOn(MyApps.methods, 'fetchAppFromRoute')
+          .mockImplementation(() => {});
+
+        mount(MyApps, {
+          global: {
+            plugins: [createTestingPinia({ createSpy: vi.fn }), i18n],
+            mocks: {
+              $router: mockRouter(),
+              $route: mockRoute({ appUuid: 'unknown-uuid', appCode: 'wwc' }),
+              $t: (msg) => msg,
+            },
+          },
+        });
+
+        await Promise.resolve();
+        expect(fetchSpy).toHaveBeenCalled();
+        fetchSpy.mockRestore();
+      });
     });
   });
 

--- a/src/tests/views/__snapshots__/MyApps.spec.js.snap
+++ b/src/tests/views/__snapshots__/MyApps.spec.js.snap
@@ -11,5 +11,11 @@ exports[`MyApps > matches snapshot 1`] = `
       <div data-v-d693ca5e="" class="my-apps__empty__description__secondary__link">here</div>
     </div>
   </div>
+  <div data-v-7d3d5e15="" data-v-d693ca5e="">
+    <transition-stub data-v-7d3d5e15="" name="fade" appear="false" persisted="false" css="true">
+      <!--v-if-->
+    </transition-stub>
+    <unnnic-modal data-v-7d3d5e15="" showmodal="false" text="Cancel modifications" scheme="feedback-yellow" modal-icon="alert-circle-1"></unnnic-modal>
+  </div>
 </div>"
 `;

--- a/src/utils/moduleFederation.js
+++ b/src/utils/moduleFederation.js
@@ -56,5 +56,8 @@ export async function safeImport(importFn, importPath) {
 
 const stripTrailingSlashes = (url = '') => url.replace(/\/+$/, '');
 
-export const isFederatedModule =
-  stripTrailingSlashes(window.location.origin) !== stripTrailingSlashes(getEnv('PUBLIC_PATH_URL'));
+export const isFederatedModule = (() => {
+  const publicPathUrl = getEnv('PUBLIC_PATH_URL') || '';
+  if (!publicPathUrl.startsWith('http')) return false;
+  return stripTrailingSlashes(window.location.origin) !== stripTrailingSlashes(publicPathUrl);
+})();

--- a/src/views/MyApps/index.vue
+++ b/src/views/MyApps/index.vue
@@ -53,24 +53,29 @@
         </div>
       </div>
     </div>
+
+    <config-modal ref="directConfigModal" @close="onDirectConfigModalClose" />
   </div>
 </template>
 
 <script>
   import AppGrid from '@/components/AppGrid/index.vue';
   import EmptyApps from '@/components/EmptyApps/index.vue';
+  import ConfigModal from '@/components/config/ConfigModal.vue';
   import { mapState, mapActions } from 'pinia';
   import unnnic from '@weni/unnnic-system';
   import { auth_store } from '@/stores/modules/auth.store';
   import { my_apps } from '@/stores/modules/myApps.store';
+  import { app_type } from '@/stores/modules/appType/appType.store';
   import { useEventStore } from '@/stores/event.store';
 
   export default {
     name: 'Apps',
-    components: { AppGrid, EmptyApps },
+    components: { AppGrid, EmptyApps, ConfigModal },
     data() {
       return {
         searchTerm: '',
+        isFetchingApp: false,
         eventStore: useEventStore(),
       };
     },
@@ -87,12 +92,13 @@
       ...mapState(auth_store, ['project']),
       ...mapState(my_apps, [
         'configuredApps',
-        'errorConfiguredApps',
+        'loadingConfiguredApps',
         'errorConfiguredApps',
         'installedApps',
         'loadingInstalledApps',
         'errorInstalledApps',
       ]),
+      ...mapState(app_type, ['currentApp', 'loadingCurrentApp', 'errorCurrentApp']),
       hasApps: function () {
         if (this.loadingConfiguredApps || this.loadingInstalledApps) {
           return true;
@@ -130,9 +136,57 @@
         return this.filterByName(this.installedApps, this.searchTerm);
       },
     },
+    watch: {
+      '$route.params.appUuid': {
+        handler(appUuid) {
+          if (!appUuid) return;
+          const app = this.configuredApps?.find((a) => a.uuid === this.$route.params.appUuid);
+          if (app) {
+            this.openConfigFromRoute(app);
+          } else {
+            this.fetchAppFromRoute();
+          }
+        },
+        immediate: true,
+      },
+    },
     methods: {
       ...mapActions(my_apps, ['getConfiguredApps', 'getInstalledApps']),
+      ...mapActions(app_type, ['getApp']),
       ...mapActions(useEventStore, ['on', 'off']),
+      openConfigFromRoute(app) {
+        this.$nextTick(() => {
+          this.$refs.directConfigModal?.openModal({ app, isConfigured: true });
+        });
+      },
+      async fetchAppFromRoute() {
+        if (this.isFetchingApp) return;
+        const { appCode, appUuid } = this.$route.params;
+        if (!appCode || !appUuid) return;
+
+        this.isFetchingApp = true;
+        await this.getApp({ code: appCode, appUuid });
+        this.isFetchingApp = false;
+
+        if (this.errorCurrentApp) {
+          unnnic.unnnicCallAlert({
+            props: { text: this.$t('apps.details.status_error'), type: 'error' },
+            seconds: 3,
+          });
+          return;
+        }
+
+        if (this.currentApp) {
+          this.$refs.directConfigModal?.openModal({ app: this.currentApp, isConfigured: true });
+        }
+      },
+      onDirectConfigModalClose() {
+        if (window.history.state?.back) {
+          this.$router.back();
+        } else {
+          this.$router.replace('/apps/my');
+        }
+      },
       filterByName(appList, search) {
         return appList.filter((app) => {
           const appMainName = app.generic ? app.config.channel_name : app.name;


### PR DESCRIPTION
## Description

### Type of Change
* * [x] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
The app config drawer could only be opened by clicking a card in the UI, making it impossible to share or bookmark a direct link to a specific app's configuration. Additionally, when `PUBLIC_PATH_URL` was set to a relative path (e.g. `/`), the app incorrectly identified the local dev environment as a federated module, preventing it from mounting at all.

### Summary of Changes

**fix — `isFederatedModule` detection for local dev**
- `src/utils/moduleFederation.js`: `isFederatedModule` now returns `false` when `PUBLIC_PATH_URL` is not an absolute URL, fixing a bug where local dev (`npm run dev`) would result in a blank white screen.

**feat — Direct URL access to the config drawer**
- `src/router/index.js`: Added route `/apps/my/configured/:appCode/:appUuid` pointing to the `MyApps` view.
- `src/components/AppGrid/index.vue`: Configured app cards (`type="edit"`) now push to the new route instead of opening the modal directly, making clicks and URL navigation consistent.
- `src/components/config/ConfigModal.vue`: Added `close` event emitted on both `closeModal` and `confirmClose`.
- `src/views/MyApps/index.vue`:
  - Mounts a dedicated `ConfigModal` driven by a `$route.params.appUuid` watcher (`immediate: true`).
  - If the app is already in the loaded list, opens the modal immediately; otherwise fetches it directly from `GET /api/v1/apptypes/:appCode/apps/:appUuid/`.
  - On modal close, navigates back in browser history or falls back to `/apps/my`.
  - Guards against duplicate fetches with an `isFetchingApp` flag.
  - Uses `$nextTick` to ensure `$refs` are available before calling `openModal`.