### PR TITLE
feat: Add ICU MessageFormat support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "weni-integrations",
-  "version": "3.13.1",
+  "version": "3.13.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "weni-integrations",
-      "version": "3.13.1",
+      "version": "3.13.2",
       "dependencies": {
         "@babel/core": "^7.23.9",
         "@babel/eslint-parser": "^7.23.10",
@@ -24,6 +24,7 @@
         "esbuild": "^0.20.2",
         "global": "^4.4.0",
         "helphero": "^3.9.0",
+        "intl-messageformat": "^11.2.8",
         "libphonenumber-js": "^1.10.56",
         "lodash.debounce": "^4.0.8",
         "lodash.snakecase": "^4.1.1",
@@ -4229,6 +4230,24 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-3.1.6.tgz",
+      "integrity": "sha512-H5aexk1Le7T9TPmscacZ+1pR6CTa2n1wq+HDVGXhH8TzUlQQpeXzZs91dRtmFHrbeNbjPFPfQujUqm7MHgVoXQ=="
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "3.5.11",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.11.tgz",
+      "integrity": "sha512-NVsuNsc2dUVG9+4HBJ/srScxtA/18LqGgwtop/tuN/OIBjVl6QA+0KhfZQddDD9sEh2LeVjLFPGVU3ixa3blcA==",
+      "dependencies": {
+        "@formatjs/icu-skeleton-parser": "2.1.10"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-2.1.10.tgz",
+      "integrity": "sha512-XuSva+8ZGawk8VnD5VD6UeH8KarQ/Z022zgjHDoHmlNiAewstXuuzXc0Hk5pGFSdG+nNw5bfJKXqj1ZXHn9yUA=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
@@ -10093,6 +10112,15 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
+    },
+    "node_modules/intl-messageformat": {
+      "version": "11.2.8",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-11.2.8.tgz",
+      "integrity": "sha512-l323RCl3qJDVQ8U9j74ut/hVMdg3VPsOHpVMDvFfz9qiq4dPO5ooVYFNVUzzrpgG39a+RLzcXyJb8VFgIU+tUA==",
+      "dependencies": {
+        "@formatjs/fast-memoize": "3.1.6",
+        "@formatjs/icu-messageformat-parser": "3.5.11"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "esbuild": "^0.20.2",
     "global": "^4.4.0",
     "helphero": "^3.9.0",
+    "intl-messageformat": "^11.2.8",
     "libphonenumber-js": "^1.10.56",
     "lodash.debounce": "^4.0.8",
     "lodash.snakecase": "^4.1.1",

--- a/setupTest.js
+++ b/setupTest.js
@@ -10,6 +10,3 @@ beforeEach(() => {
   setActivePinia(pinia);
 });
 config.global.plugins = [i18n];
-config.mocks = {
-  $t: (msg) => msg,
-};

--- a/src/components/NavBar/index.vue
+++ b/src/components/NavBar/index.vue
@@ -1,8 +1,12 @@
 <template>
   <div id="topnav">
-    <router-link class="link" :to="{ name: 'Discovery' }">{{ $t('apps.nav.discovery') }}</router-link>
+    <router-link class="link" :to="{ name: 'Discovery' }">{{
+      $t('apps.nav.discovery')
+    }}</router-link>
     <router-link class="link" :to="{ name: 'Apps' }">{{ $t('apps.nav.my_apps') }}</router-link>
-    <router-link class="link" :to="{ name: 'Other Apps' }">{{ $t('apps.nav.other_apps') }}</router-link>
+    <router-link class="link" :to="{ name: 'Other Apps' }">{{
+      $t('apps.nav.other_apps')
+    }}</router-link>
   </div>
 </template>
 <script>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -208,7 +208,7 @@
       "unread_messages_indicator": "Unread messages indicator",
       "keep_chat_history": "Keep chat history",
       "time_between_messages": "Time between messages",
-      "time_between_messages_option": "{ count } second | { count } seconds",
+      "time_between_messages_option": "{count, plural, one {{count} second} other {{count} seconds}}",
       "time_between_messages_message": "Interval between agent messages",
       "navigate_if_same_domain": {
         "label": "Allow Webchat to automatically redirect the page",

--- a/src/locales/es_es.json
+++ b/src/locales/es_es.json
@@ -208,7 +208,7 @@
       "unread_messages_indicator": "Indicador de mensajes no leídos",
       "keep_chat_history": "Mantener historial de mensajes",
       "time_between_messages": "Tiempo entre mensajes",
-      "time_between_messages_option": "{ count } segundo | { count } segundos",
+      "time_between_messages_option": "{count, plural, one {{count} segundo} other {{count} segundos}}",
       "time_between_messages_message": "Intervalo entre mensajes del agente",
       "navigate_if_same_domain": {
         "label": "Permitir que el Webchat redirija automáticamente la página",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -208,7 +208,7 @@
       "unread_messages_indicator": "Indicador de mensagens não lidas",
       "keep_chat_history": "Manter histórico de mensagens",
       "time_between_messages": "Tempo entre as mensagens",
-      "time_between_messages_option": "{ count } segundo | { count } segundos",
+      "time_between_messages_option": "{count, plural, one {{count} segundo} other {{count} segundos}}",
       "time_between_messages_message": "Intervalo entre mensagens do agente",
       "navigate_if_same_domain": {
         "label": "Permitir que o Webchat redirecione automaticamente a página",

--- a/src/tests/components/AddModal.spec.js
+++ b/src/tests/components/AddModal.spec.js
@@ -12,7 +12,6 @@ describe('AddModal', () => {
           $router: {
             replace: vi.fn(),
           },
-          $t: (e) => e,
         },
       },
     });

--- a/src/tests/components/AppGrid.spec.js
+++ b/src/tests/components/AppGrid.spec.js
@@ -41,7 +41,6 @@ describe('AppGrid', () => {
             ],
             avatar: avatarIcons.channel,
           },
-          $t: (e) => e,
         },
       },
     });
@@ -106,7 +105,6 @@ describe('AppGrid', () => {
             plugins: [pinia, i18n],
             mocks: {
               $router: { push: pushMock },
-              $t: (e) => e,
             },
           },
         });
@@ -142,7 +140,7 @@ describe('AppGrid', () => {
           props: { section: 'configured', type: 'add', apps: [genericApp] },
           global: {
             plugins: [pinia, i18n],
-            mocks: { $router: { push: pushMock }, $t: (e) => e },
+            mocks: { $router: { push: pushMock } },
           },
         });
         await w.vm.openAppModal(genericApp);

--- a/src/tests/components/NavBar.spec.js
+++ b/src/tests/components/NavBar.spec.js
@@ -33,9 +33,6 @@ describe('NavBar.vue', () => {
     wrapper = mount(NavBar, {
       global: {
         plugins: [i18n, UnnnicSystem, router],
-        mocks: {
-          $t: (msg) => msg,
-        },
       },
     });
   });

--- a/src/tests/components/TemplateDetails/Summary.spec.js
+++ b/src/tests/components/TemplateDetails/Summary.spec.js
@@ -26,9 +26,6 @@ describe('Summary.vue', () => {
     wrapper = mount(Summary, {
       global: {
         plugins: [pinia, i18n, UnnnicSystem],
-        mocks: {
-          $t: (msg) => msg,
-        },
         methods: {
           fetchTemplateAnalyticsWeek: vi.fn(),
         },
@@ -62,9 +59,6 @@ describe('Summary.vue', () => {
     wrapper = mount(Summary, {
       global: {
         plugins: [pinia, i18n, UnnnicSystem],
-        mocks: {
-          $t: (msg) => msg,
-        },
         methods: {
           fetchTemplateAnalyticsWeek: vi.fn(),
         },

--- a/src/tests/components/WhatsAppTemplates/FormTabs.spec.js
+++ b/src/tests/components/WhatsAppTemplates/FormTabs.spec.js
@@ -131,9 +131,6 @@ describe('FormTabs.vue', () => {
     const wrapper = mount(FormTabs, {
       global: {
         plugins: [pinia, i18n, UnnnicSystem, router],
-        mocks: {
-          $t: (msg) => msg,
-        },
       },
       mocks: {
         formMode: 'edit',

--- a/src/tests/components/app/AppDetailsAbout.spec.js
+++ b/src/tests/components/app/AppDetailsAbout.spec.js
@@ -15,9 +15,6 @@ describe('AppDetailsAbout.vue', () => {
     wrapper = mount(AppDetailsAbout, {
       global: {
         plugins: [pinia, i18n, UnnnicSystem],
-        mocks: {
-          $t: (msg) => msg,
-        },
       },
       props: {
         description: 'This is a sample app description.',
@@ -53,9 +50,6 @@ describe('AppDetailsAbout.vue', () => {
     wrapper = mount(AppDetailsAbout, {
       global: {
         plugins: [pinia, i18n, UnnnicSystem],
-        mocks: {
-          $t: (msg) => msg,
-        },
       },
       props: {
         description: 'This is a sample app description.',

--- a/src/tests/components/app/AppDetailsComments.spec.js
+++ b/src/tests/components/app/AppDetailsComments.spec.js
@@ -25,9 +25,6 @@ describe('AppDetailsComments.vue', () => {
     wrapper = mount(AppDetailsComments, {
       global: {
         plugins: [pinia, i18n, UnnnicSystem],
-        mocks: {
-          $t: (msg) => msg,
-        },
       },
       props: {
         appCode,

--- a/src/tests/components/app/AppDetailsRecommended.spec.js
+++ b/src/tests/components/app/AppDetailsRecommended.spec.js
@@ -12,7 +12,6 @@ describe('AppDetailsRecommended.vue', () => {
       global: {
         plugins: [i18n, UnnnicSystem],
         mocks: {
-          $t: (msg) => msg,
           $router: {
             push: vi.fn(),
           },

--- a/src/tests/components/config/channels/facebook/Setup.spec.js
+++ b/src/tests/components/config/channels/facebook/Setup.spec.js
@@ -31,7 +31,6 @@ describe('FacebookSetup.vue', () => {
         plugins: [pinia, i18n, UnnnicSystem],
         mocks: {
           $router: { replace: vi.fn() },
-          $t: (e) => e,
         },
       },
       props: { app: mockApp },

--- a/src/tests/components/config/channels/telegram/Config.spec.js
+++ b/src/tests/components/config/channels/telegram/Config.spec.js
@@ -33,7 +33,6 @@ describe('Config.vue', () => {
         plugins: [pinia, i18n, UnnnicSystem],
         mocks: {
           unnnic,
-          $t: (e) => e,
         },
       },
     });

--- a/src/tests/components/config/channels/whatsapp/Setup.spec.js
+++ b/src/tests/components/config/channels/whatsapp/Setup.spec.js
@@ -48,7 +48,6 @@ describe('WhatsAppSetup.vue', () => {
           $router: {
             replace: vi.fn(),
           },
-          $t: (e) => e,
         },
       },
     });

--- a/src/tests/components/config/channels/whatsapp/components/tabs/ConversationsTab.spec.js
+++ b/src/tests/components/config/channels/whatsapp/components/tabs/ConversationsTab.spec.js
@@ -21,7 +21,6 @@ describe('ConversationsTab', () => {
       global: {
         plugins: [i18n, UnnnicSystem, pinia],
         mocks: {
-          $t: (key) => key,
           $router: { replace: vi.fn() },
           unnnic,
         },

--- a/src/tests/components/config/channels/wpp_demo/Preview.spec.js
+++ b/src/tests/components/config/channels/wpp_demo/Preview.spec.js
@@ -32,7 +32,6 @@ describe('wpp-demo-preview Component', () => {
         plugins: [pinia, i18n, UnnnicSystem],
         mocks: {
           unnnic,
-          $t: (e) => e,
         },
       },
     });

--- a/src/tests/components/config/ecommerce/vtex/Config.spec.js
+++ b/src/tests/components/config/ecommerce/vtex/Config.spec.js
@@ -39,7 +39,6 @@ describe('vtex-config Component', () => {
           $router: {
             push: vi.fn(),
           },
-          $t: (e) => e,
         },
       },
     });

--- a/src/tests/utils/plugins/icuMessageCompiler.spec.js
+++ b/src/tests/utils/plugins/icuMessageCompiler.spec.js
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import * as VueI18n from 'vue-i18n';
+
+import icuMessageCompiler, { shouldUseIntlMessageFormat } from '@/utils/plugins/icuMessageCompiler';
+
+const createInstance = (messages) =>
+  VueI18n.createI18n({
+    legacy: false,
+    locale: 'en-us',
+    fallbackLocale: 'en-us',
+    messages,
+    messageCompiler: icuMessageCompiler,
+  });
+
+describe('icuMessageCompiler', () => {
+  describe('shouldUseIntlMessageFormat', () => {
+    it('detects ICU plural messages', () => {
+      expect(shouldUseIntlMessageFormat('{count, plural, one {item} other {items}}')).toBe(true);
+    });
+
+    it('detects ICU select messages', () => {
+      expect(shouldUseIntlMessageFormat('{gender, select, male {he} other {they}}')).toBe(true);
+    });
+
+    it('ignores plain strings that merely contain the words plural or select', () => {
+      expect(shouldUseIntlMessageFormat('Select an option to continue')).toBe(false);
+      expect(shouldUseIntlMessageFormat('Choose a plural form below')).toBe(false);
+    });
+  });
+
+  describe('plain messages', () => {
+    it('resolves named placeholders', () => {
+      const i18n = createInstance({ 'en-us': { greeting: 'Hello {name}' } });
+      expect(i18n.global.t('greeting', { name: 'Ana' })).toBe('Hello Ana');
+    });
+
+    it('resolves named placeholders written with surrounding spaces', () => {
+      const i18n = createInstance({ 'en-us': { greeting: 'Hello { name }' } });
+      expect(i18n.global.t('greeting', { name: 'Ana' })).toBe('Hello Ana');
+    });
+
+    it('keeps unprovided placeholders literally', () => {
+      const i18n = createInstance({ 'en-us': { value: 'Value {missing}' } });
+      expect(i18n.global.t('value')).toBe('Value {missing}');
+    });
+
+    it('preserves literal double curly brackets used as example text', () => {
+      const message = 'Use two sets of curly brackets (for example, {{1}}, {{2}}).';
+      const i18n = createInstance({ 'en-us': { hint: message } });
+      expect(i18n.global.t('hint')).toBe(message);
+    });
+  });
+
+  describe('ICU plural messages', () => {
+    const messages = {
+      'en-us': {
+        seconds: '{count, plural, one {{count} second} other {{count} seconds}}',
+      },
+      'pt-br': {
+        seconds: '{count, plural, one {{count} segundo} other {{count} segundos}}',
+      },
+    };
+
+    it('selects the singular branch', () => {
+      const i18n = createInstance(messages);
+      expect(i18n.global.t('seconds', { count: 1 })).toBe('1 second');
+    });
+
+    it('selects the plural branch', () => {
+      const i18n = createInstance(messages);
+      expect(i18n.global.t('seconds', { count: 2 })).toBe('2 seconds');
+    });
+
+    it('uses the locale plural rules of the active locale', () => {
+      const i18n = createInstance(messages);
+      i18n.global.locale.value = 'pt-br';
+      expect(i18n.global.t('seconds', { count: 1 })).toBe('1 segundo');
+      expect(i18n.global.t('seconds', { count: 3 })).toBe('3 segundos');
+    });
+  });
+
+  describe('falls back to the key for AST messages', () => {
+    it('returns the key when the message is not a string', () => {
+      const compiled = icuMessageCompiler({ type: 0 }, { locale: 'en-us', key: 'some.key' });
+      expect(compiled()).toBe('some.key');
+    });
+  });
+});

--- a/src/utils/plugins/i18n.js
+++ b/src/utils/plugins/i18n.js
@@ -1,5 +1,6 @@
 import * as VueI18n from 'vue-i18n';
 
+import icuMessageCompiler from '@/utils/plugins/icuMessageCompiler';
 import en from '../../locales/en.json';
 import pt_br from '../../locales/pt_br.json';
 import es_es from '../../locales/es_es.json';
@@ -13,9 +14,12 @@ const languages = {
 const messages = Object.assign(languages);
 
 const i18n = VueI18n.createI18n({
+  legacy: false,
+  globalInjection: true,
   locale: 'en-us',
   fallbackLocale: 'en-us',
   messages,
+  messageCompiler: icuMessageCompiler,
 });
 
 export default i18n;

--- a/src/utils/plugins/icuMessageCompiler.js
+++ b/src/utils/plugins/icuMessageCompiler.js
@@ -1,0 +1,117 @@
+import IntlMessageFormat from 'intl-messageformat';
+
+/**
+ * Matches real ICU blocks only: {var, plural|selectordinal, { … }
+ * or {var, select, { … }. Avoids false positives like
+ * "{user, select another option}" or "{item, plural forms available}".
+ */
+const ICU_PLURAL_OR_SELECTORDINAL_PATTERN =
+  /\{([a-zA-Z][\w]*),\s*(?:plural|selectordinal)\s*,\s*(?:(?:=\d+)|zero|one|two|few|many|other)\s*\{/i;
+
+const ICU_SELECT_PATTERN = /\{([a-zA-Z][\w]*),\s*select\s*,\s*[\w#.-]+\s*\{/i;
+
+export function shouldUseIntlMessageFormat(message) {
+  return ICU_PLURAL_OR_SELECTORDINAL_PATTERN.test(message) || ICU_SELECT_PATTERN.test(message);
+}
+
+/** Tag names in ICU XML markup (<b>, <i>, <br>) need function handlers in .format(). */
+const ICU_XML_TAG_PATTERN = /<\/?([a-zA-Z][a-zA-Z0-9]*)\b/g;
+
+const NAMED_PLACEHOLDER_PATTERN = /\{\s*(\w+)\s*\}/g;
+
+/**
+ * Builds the message parts for plain (non-ICU) strings, resolving `{name}`
+ * placeholders through the message context. Unprovided placeholders are kept
+ * literally to preserve the previous behavior. Returning context-resolved parts
+ * lets `ctx.normalize` produce a string for `t()` and vnodes for the
+ * `<i18n-t>` component.
+ */
+function buildPlainMessageParts(message, ctx) {
+  const values = ctx.values || {};
+  const parts = [];
+  let lastIndex = 0;
+  let match;
+
+  NAMED_PLACEHOLDER_PATTERN.lastIndex = 0;
+  while ((match = NAMED_PLACEHOLDER_PATTERN.exec(message)) !== null) {
+    const [token, name] = match;
+
+    if (match.index > lastIndex) {
+      parts.push(message.slice(lastIndex, match.index));
+    }
+
+    if (Object.prototype.hasOwnProperty.call(values, name)) {
+      parts.push(ctx.interpolate(ctx.named(name)));
+    } else {
+      parts.push(token);
+    }
+
+    lastIndex = NAMED_PLACEHOLDER_PATTERN.lastIndex;
+  }
+
+  if (lastIndex < message.length) {
+    parts.push(message.slice(lastIndex));
+  }
+
+  return parts;
+}
+
+function createDefaultTagHandler(tagName) {
+  if (tagName === 'br') {
+    return (chunks) => chunks.join('') + '\n';
+  }
+
+  return (chunks) => {
+    const content = chunks.join('');
+    return `<${tagName}>${content}</${tagName}>`;
+  };
+}
+
+/**
+ * Merges $t params with default ICU tag handlers so plural + HTML works without
+ * passing b/i/br manually on every call.
+ */
+function buildIntlFormatValues(message, values = {}) {
+  const formatValues = { ...(values || {}) };
+  let match;
+
+  while ((match = ICU_XML_TAG_PATTERN.exec(message)) !== null) {
+    const tagName = match[1];
+    const existing = formatValues[tagName];
+
+    if (typeof existing === 'function') {
+      continue;
+    }
+
+    formatValues[tagName] = createDefaultTagHandler(tagName);
+  }
+
+  ICU_XML_TAG_PATTERN.lastIndex = 0;
+  return formatValues;
+}
+
+/**
+ * Vue I18n custom messageCompiler: ICU plural/select via IntlMessageFormat;
+ * plain strings (HTML, simple {name}) use named interpolation only.
+ * Both branches return through `ctx.normalize` so the same compiled function
+ * supports `t()` (string output) and `<i18n-t>` (vnode array output).
+ */
+const icuMessageCompiler = (message, { locale, key, onError }) => {
+  if (typeof message === 'string') {
+    if (shouldUseIntlMessageFormat(message)) {
+      const formatter = new IntlMessageFormat(message, locale);
+      return (ctx) => {
+        const formatted = formatter.format(buildIntlFormatValues(message, ctx.values));
+        const parts = Array.isArray(formatted) ? formatted : [formatted];
+        return ctx.normalize(parts);
+      };
+    }
+
+    return (ctx) => ctx.normalize(buildPlainMessageParts(message, ctx));
+  }
+
+  onError?.(new Error('not support for AST'));
+  return () => key;
+};
+
+export default icuMessageCompiler;


### PR DESCRIPTION
## Description

### Type of Change
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [x] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
Translations follow the ICU Message Format used across the platform (VTEX localization delivers plural strings in ICU). This webapp, however, used vue-i18n's native pipe (`|`) pluralization syntax, so any ICU-formatted plural delivered by translations would not render correctly. This aligns the webapp with the platform standard (same approach as `agent-builder-webapp`) so plural/select messages render correctly while keeping every existing translation working.

### Summary of Changes
- Added `intl-messageformat` and a custom vue-i18n `messageCompiler` (`src/utils/plugins/icuMessageCompiler.js`).
  - The compiler routes a message through `IntlMessageFormat` **only** when it matches ICU `plural`/`select` syntax; every other string goes through a plain `{name}` interpolation path that preserves literal braces (e.g. `{{1}}, {{2}}`) and apostrophes. This guarantees existing translations are unchanged.
- Switched vue-i18n to composition mode (`legacy: false`, `globalInjection: true`) in `src/utils/plugins/i18n.js`. This is required because vue-i18n's legacy mode silently drops the `messageCompiler` option (`convertComposerOptions` does not forward it). Verified that Options API `$t`/`$te` and `this.$i18n.locale` get/set keep working under `globalInjection`.
- Converted the only pipe-pluralized message (`weniWebChat.config.time_between_messages_option`) to ICU plural (`one`/`other`) in `en.json`, `pt_br.json`, and `es_es.json`. Its call sites in `PreferencesTab.vue` already pass `{ count }`, so no component change was needed.
- Added a unit test for the compiler (plain `{name}` interpolation, ICU plural selection across locales, literal-brace preservation, AST fallback).
- Removed the now-redundant identity `$t: (msg) => msg` test mocks. Under legacy mode the per-instance mixin `$t` always overrode these mocks, so specs were really asserting real translations; in composition mode the mocks would shadow the real `$t`, so they were dropped to keep behavior intact.
