### PR TITLE
🐛 Fix WWC custom CSS not loading in config drawer 

### DIFF
--- a/src/components/config/channels/WWC/Config.vue
+++ b/src/components/config/channels/WWC/Config.vue
@@ -376,14 +376,6 @@
       config.avatarFile = await dataUrlToFile(selectedApp.value.config.profileAvatar, 'avatar.png');
       setTimeout(() => emit('setConfirmation', false), 250);
     }
-
-    if (selectedApp.value.config.customCss) {
-      const file = await dataUrlToFile(selectedApp.value.config.customCss, 'style.css');
-      if (file) {
-        config.customCssFile = file;
-        setTimeout(() => emit('setConfirmation', false), 250);
-      }
-    }
   });
 
   // Watch displayUnreadCount to close simulator when enabled

--- a/src/components/config/channels/WWC/components/tabs/AppearanceTab.vue
+++ b/src/components/config/channels/WWC/components/tabs/AppearanceTab.vue
@@ -168,6 +168,22 @@
   const cssFiles = ref([]);
   const avatarBase64 = ref(props.initialAvatarBase64);
 
+  function isFetchableCssValue(value) {
+    return (
+      value.startsWith('data:') || value.startsWith('http://') || value.startsWith('https://')
+    );
+  }
+
+  async function customCssToFile(cssValue) {
+    if (!cssValue) return null;
+
+    if (isFetchableCssValue(cssValue)) {
+      return dataUrlToFile(cssValue, 'style.css');
+    }
+
+    return new File([cssValue], 'style.css', { type: 'text/css' });
+  }
+
   // Initialize displayed fields based on initial values
   onMounted(async () => {
     APPEARANCE_FIELDS.forEach((field) => {
@@ -187,6 +203,11 @@
     // Initialize CSS file
     if (props.initialCssFile) {
       cssFiles.value = [props.initialCssFile];
+    } else if (props.initialCustomCss) {
+      const file = await customCssToFile(props.initialCustomCss);
+      if (file) {
+        cssFiles.value = [file];
+      }
     }
   });
 

--- a/src/tests/components/config/channels/WWC/tabs/AppearanceTab.spec.js
+++ b/src/tests/components/config/channels/WWC/tabs/AppearanceTab.spec.js
@@ -398,6 +398,34 @@ describe('AppearanceTab', () => {
       expect(cssUpload.attributes('files')).toBe('[object File]');
     });
 
+    it('should pass the existing CSS file to the upload area when initialCustomCss is a URL', async () => {
+      wrapper = createWrapper({
+        initialCustomCss: 'https://example.com/custom.css',
+      });
+      await flushPromises();
+
+      const cssUpload = findUploadAreas(wrapper)[1];
+      expect(cssUpload.attributes('files')).toBe('[object File]');
+    });
+
+    it('should pass the existing CSS file to the upload area when initialCustomCss is plain text', async () => {
+      wrapper = createWrapper({
+        initialCustomCss: '.test { color: red; }',
+      });
+      await flushPromises();
+
+      const cssUpload = findUploadAreas(wrapper)[1];
+      expect(cssUpload.attributes('files')).toBe('[object File]');
+    });
+
+    it('should not populate the upload area when initialCustomCss and initialCssFile are missing', async () => {
+      wrapper = createWrapper({ initialCustomCss: null, initialCssFile: null });
+      await flushPromises();
+
+      const cssUpload = findUploadAreas(wrapper)[1];
+      expect(cssUpload.attributes('files') || '').toBe('');
+    });
+
     it('should emit null update:cssFile and update:customCss when the upload area clears the file', async () => {
       const existingCssFile = new File(['body {}'], 'style.css', { type: 'text/css' });
       wrapper = createWrapper({ initialCssFile: existingCssFile });


### PR DESCRIPTION
## Description
### Type of Change
* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [x] Tests
* [ ] Other

### Motivation and Context
When opening the WWC configuration drawer for an already configured integration, the custom CSS upload area was not populated with the existing file. This prevented users from viewing or removing the current custom CSS.

The issue was caused by a race condition: `AppearanceTab` only initialized the upload from `initialCssFile`, which was `null` on mount, while `Config.vue` converted `customCss` to a file asynchronously after the child component had already mounted. Unlike the avatar upload — which correctly uses `initialAvatarBase64` directly — the CSS upload ignored the `initialCustomCss` prop entirely.

### Summary of Changes
- Updated `AppearanceTab.vue` to initialize the CSS upload area from `initialCustomCss` when `initialCssFile` is not available, mirroring the avatar initialization pattern
- Added support for both fetchable values (URL/data URL) and plain CSS text when converting `customCss` to a `File`
- Removed duplicate `customCss` conversion logic from `Config.vue` `onMounted`, since display initialization is now handled in `AppearanceTab`
- Added tests covering URL-based CSS, plain text CSS, and the empty state when no CSS is configured