### PR TITLE
✨ Rename Web Chat to Shopping Assistant in UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+3.14.0
+----------
+`2026-06-22 · 1 🔧`
+
+### 🔧 Improvements
+- Rename Web Chat to Shopping Assistant in UI copy and app display names
+
 3.13.3
 ----------
 `2026-06-12 · 1 🐛 · 1 🔧`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "weni-integrations",
-  "version": "3.13.3",
+  "version": "3.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "weni-integrations",
-      "version": "3.13.3",
+      "version": "3.14.0",
       "dependencies": {
         "@babel/core": "^7.23.9",
         "@babel/eslint-parser": "^7.23.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weni-integrations",
-  "version": "3.13.3",
+  "version": "3.14.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/components/AppGrid/index.vue
+++ b/src/components/AppGrid/index.vue
@@ -144,6 +144,7 @@
   import { mapActions, mapState } from 'pinia';
   import { app_type } from '../../stores/modules/appType/appType.store';
   import { storeToRefs } from 'pinia';
+  import { getAppDisplayName } from '@/utils/apps';
   export default {
     name: 'AppGrid',
     components: { configModal, IntegrateButton, LoadingButton, skeletonLoading },
@@ -296,7 +297,7 @@
           }`;
         }
 
-        return `${app.name}${
+        return `${getAppDisplayName(app, this.$t.bind(this))}${
           this.type === 'edit'
             ? ' - ' + (app.config.title || app.config.name || app.config.username)
             : ''

--- a/src/components/app/AppDetailsHeader.vue
+++ b/src/components/app/AppDetailsHeader.vue
@@ -4,7 +4,7 @@
       <img class="app-details-header__icon__src" :src="app?.icon" />
     </div>
     <div class="app-details-header__content">
-      <div class="app-details-header__content__title">{{ app?.name }}</div>
+      <div class="app-details-header__content__title">{{ displayName }}</div>
       <div class="app-details-header__content__description">{{ $t(app?.summary || '') }}</div>
     </div>
     <integrate-button
@@ -26,6 +26,7 @@
 <script>
   import addModal from '../AddModal/index.vue';
   import IntegrateButton from '../IntegrateButton/index.vue';
+  import { getAppDisplayName } from '@/utils/apps';
 
   export default {
     name: 'AppDetailsHeader',
@@ -37,6 +38,9 @@
       },
     },
     computed: {
+      displayName() {
+        return getAppDisplayName(this.app, this.$t.bind(this));
+      },
       cssVars() {
         return {
           '--icon-bg-color': this.app?.bg_color || 'white',

--- a/src/components/config/channels/WWC/Config.vue
+++ b/src/components/config/channels/WWC/Config.vue
@@ -2,7 +2,7 @@
   <div class="app-config-wwc">
     <div class="app-config-wwc__header">
       <div class="app-config-wwc__header__title-container">
-        <h1 class="app-config-wwc__header__title">{{ selectedApp.name }}</h1>
+        <h1 class="app-config-wwc__header__title">{{ appDisplayName }}</h1>
         <p class="app-config-wwc__header__description">
           {{ $t('weniWebChat.config.description') }}
         </p>
@@ -150,6 +150,7 @@
   import { useEventStore } from '@/stores/event.store';
   import { dataUrlToFile, toBase64 } from '@/utils/files';
   import removeEmpty from '@/utils/clean';
+  import { getAppDisplayName } from '@/utils/apps';
   import { DEFAULT_COLOR, formatContactTimeout, parseContactTimeout } from './constants';
   import AppearanceTab from './components/tabs/AppearanceTab.vue';
   import PreferencesTab from './components/tabs/PreferencesTab.vue';
@@ -228,6 +229,8 @@
   });
 
   const chatSubtitle = computed(() => config.subtitle || ' ');
+
+  const appDisplayName = computed(() => getAppDisplayName(selectedApp.value, t));
 
   const loadingSave = computed(() => loadingUpdateAppConfig.value || loadingCurrentApp.value);
 

--- a/src/components/config/channels/WWC/components/tabs/AppearanceTab.vue
+++ b/src/components/config/channels/WWC/components/tabs/AppearanceTab.vue
@@ -169,9 +169,7 @@
   const avatarBase64 = ref(props.initialAvatarBase64);
 
   function isFetchableCssValue(value) {
-    return (
-      value.startsWith('data:') || value.startsWith('http://') || value.startsWith('https://')
-    );
+    return value.startsWith('data:') || value.startsWith('http://') || value.startsWith('https://');
   }
 
   async function customCssToFile(cssValue) {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -175,17 +175,18 @@
   },
   "weniWebChat": {
     "data": {
-      "summary": "With Web Chat, you can integrate your project as a chat on your website.",
-      "description": "Use Web Chat to have a humanized automation experience of VTEX Agentic CX directly on your website or web platform. By integrating it, you can customize aspects of the Web Chat such as Color, the timing between messages, message indicators, avatar, and more! Thus, guaranteeing everything that VTEX Agentic CX Platform has to offer with your's brand identity.",
+      "name": "Shopping Assistant",
+      "summary": "With Shopping Assistant, you can integrate your project as a chat on your website.",
+      "description": "Use Shopping Assistant to have a humanized automation experience of VTEX Agentic CX directly on your website or web platform. By integrating it, you can customize aspects of the Shopping Assistant such as Color, the timing between messages, message indicators, avatar, and more! Thus, guaranteeing everything that VTEX Agentic CX Platform has to offer with your's brand identity.",
       "links": {
         "create_channel": {
-          "label": "Adding a Web Channel",
+          "label": "Adding a Shopping Assistant channel",
           "url": "https://docs.weni.ai/l/en/weni-integrations/adding-a-web-channel"
         }
       }
     },
     "config": {
-      "description": "Learn more about how to integrate Web Chat here.",
+      "description": "Learn more about how to integrate Shopping Assistant here.",
       "settings": "Settings",
       "script": "Script Code",
       "appearance": "Appearance",
@@ -194,7 +195,7 @@
       "media": "Media",
       "retail": "Retail",
       "history": "Chat history & Inactivity",
-      "script_tutorial": "To install Web Chat on your website, copy and paste this code above the last <<strong>/body</strong>> on your website.",
+      "script_tutorial": "To install Shopping Assistant on your website, copy and paste this code above the last <<strong>/body</strong>> on your website.",
       "script_disclaimer": "The script will be available once the required basic settings have been completed.",
       "download_script": "Download Script",
       "custom_css": "Custom CSS",
@@ -211,8 +212,8 @@
       "time_between_messages_option": "{count, plural, one {{count} second} other {{count} seconds}}",
       "time_between_messages_message": "Interval between agent messages",
       "navigate_if_same_domain": {
-        "label": "Allow Webchat to automatically redirect the page",
-        "helper": "When enabled, Webchat can automatically redirect the user to another page when a link is sent during the conversation. This feature is currently in Beta and may change."
+        "label": "Allow Shopping Assistant to automatically redirect the page",
+        "helper": "When enabled, Shopping Assistant can automatically redirect the user to another page when a link is sent during the conversation. This feature is currently in Beta and may change."
       },
       "conversation_starters_pdp": {
         "label": "AI-Suggested Questions",
@@ -220,7 +221,7 @@
       },
       "add_to_cart": {
         "label": "Add to cart on store",
-        "helper": "Shoppers can add AI-suggested products directly to the store's native cart instead of a Webchat-managed cart. Recommended for stores with custom cart or checkout flows."
+        "helper": "Shoppers can add AI-suggested products directly to the store's native cart instead of a Shopping Assistant-managed cart. Recommended for stores with custom cart or checkout flows."
       },
       "main_color": "Main color",
       "save_changes": "Save changes",

--- a/src/locales/es_es.json
+++ b/src/locales/es_es.json
@@ -175,17 +175,18 @@
   },
   "weniWebChat": {
     "data": {
-      "summary": "Con Web Chat, puede integrar su proyecto como un chat en su sitio web.",
-      "description": "Utilice Web Chat para brindar una experiencia de automatización humanizada de VTEX Agentic CX directamente en su sitio web o plataforma web. Al integrarlo, puede personalizar aspectos del Web Chat como el color, el tiempo entre mensajes, los indicadores de mensajes, el avatar ¡y más! Así, garantiza todo lo que VTEX Agentic CX tiene para ofrecer con la identidad de su marca.",
+      "name": "Shopping Assistant",
+      "summary": "Con Shopping Assistant, puede integrar su proyecto como un chat en su sitio web.",
+      "description": "Utilice Shopping Assistant para brindar una experiencia de automatización humanizada de VTEX Agentic CX directamente en su sitio web o plataforma web. Al integrarlo, puede personalizar aspectos del Shopping Assistant como el color, el tiempo entre mensajes, los indicadores de mensajes, el avatar ¡y más! Así, garantiza todo lo que VTEX Agentic CX tiene para ofrecer con la identidad de su marca.",
       "links": {
         "create_channel": {
-          "label": "Agregar un Canal Web",
+          "label": "Agregar un canal Shopping Assistant",
           "url": "https://docs.weni.ai/l/en/weni-integrations/adding-a-web-channel"
         }
       }
     },
     "config": {
-      "description": "Aprenda más sobre cómo integrar Web Chat aquí.",
+      "description": "Aprenda más sobre cómo integrar Shopping Assistant aquí.",
       "settings": "Ajustes",
       "script": "Código Script",
       "appearance": "Apariencia",
@@ -194,7 +195,7 @@
       "media": "Medios",
       "retail": "Minorista",
       "history": "Historial de chat & Inactividad",
-      "script_tutorial": "Para instalar Web Chat en su sitio web, copie y pegue este código encima del último <<strong>/body</strong>> en su sitio web.",
+      "script_tutorial": "Para instalar Shopping Assistant en su sitio web, copie y pegue este código encima del último <<strong>/body</strong>> en su sitio web.",
       "script_disclaimer": "El script estará disponible una vez que se completen los ajustes básicos requeridos.",
       "download_script": "Descargar Script",
       "custom_css": "CSS personalizado",
@@ -211,8 +212,8 @@
       "time_between_messages_option": "{count, plural, one {{count} segundo} other {{count} segundos}}",
       "time_between_messages_message": "Intervalo entre mensajes del agente",
       "navigate_if_same_domain": {
-        "label": "Permitir que el Webchat redirija automáticamente la página",
-        "helper": "Cuando está habilitado, el Webchat puede redirigir automáticamente al usuario a otra página cuando se envía un enlace durante la conversación. Esta funcionalidad está actualmente en Beta y puede cambiar."
+        "label": "Permitir que Shopping Assistant redirija automáticamente la página",
+        "helper": "Cuando está habilitado, Shopping Assistant puede redirigir automáticamente al usuario a otra página cuando se envía un enlace durante la conversación. Esta funcionalidad está actualmente en Beta y puede cambiar."
       },
       "conversation_starters_pdp": {
         "label": "Preguntas sugeridas por IA",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -175,17 +175,18 @@
   },
   "weniWebChat": {
     "data": {
-      "summary": "Com o Web Chat, você pode integrar seu projeto como um chat em seu site.",
-      "description": "Use o Web Chat para ter a experiência de automação humanizada da VTEX Agentic CX diretamente no seu site ou plataforma web. Ao integrar o canal, você consegue customizar aspectos do Web Chat como: Cor, espaçamento entre mensagens, indicadores de mensagem, avatar, e muito mais! Assim, garantindo tudo que VTEX Agentic CX tem a oferecer, com a cara da sua marca.",
+      "name": "Shopping Assistant",
+      "summary": "Com o Shopping Assistant, você pode integrar seu projeto como um chat em seu site.",
+      "description": "Use o Shopping Assistant para ter a experiência de automação humanizada da VTEX Agentic CX diretamente no seu site ou plataforma web. Ao integrar o canal, você consegue customizar aspectos do Shopping Assistant como: Cor, espaçamento entre mensagens, indicadores de mensagem, avatar, e muito mais! Assim, garantindo tudo que VTEX Agentic CX tem a oferecer, com a cara da sua marca.",
       "links": {
         "create_channel": {
-          "label": "Como criar um canal Web Chat",
+          "label": "Como criar um canal Shopping Assistant",
           "url": "https://docs.weni.ai/l/pt/m-dulo-integra-es/como-criar-um-canal-web"
         }
       }
     },
     "config": {
-      "description": "Saiba mais sobre como integrar o Web Chat aqui.",
+      "description": "Saiba mais sobre como integrar o Shopping Assistant aqui.",
       "settings": "Configurações",
       "script": "Código Script",
       "appearance": "Aparência",
@@ -194,7 +195,7 @@
       "history": "Histórico de chat & Inatividade",
       "media": "Mídia",
       "retail": "Varejo",
-      "script_tutorial": "Para instalar o Web Chat no seu site, copie e cole este código acima da última tag <<strong>/body</strong>> no seu site",
+      "script_tutorial": "Para instalar o Shopping Assistant no seu site, copie e cole este código acima da última tag <<strong>/body</strong>> no seu site",
       "script_disclaimer": "O script estará disponível uma vez que os ajustes básicos necessários forem completados.",
       "download_script": "Baixar Script",
       "custom_css": "CSS Customizado",
@@ -211,8 +212,8 @@
       "time_between_messages_option": "{count, plural, one {{count} segundo} other {{count} segundos}}",
       "time_between_messages_message": "Intervalo entre mensagens do agente",
       "navigate_if_same_domain": {
-        "label": "Permitir que o Webchat redirecione automaticamente a página",
-        "helper": "Quando habilitado, o Webchat pode redirecionar automaticamente o usuário para outra página quando um link é enviado durante a conversa. Esta funcionalidade está atualmente em Beta e pode mudar."
+        "label": "Permitir que o Shopping Assistant redirecione automaticamente a página",
+        "helper": "Quando habilitado, o Shopping Assistant pode redirecionar automaticamente o usuário para outra página quando um link é enviado durante a conversa. Esta funcionalidade está atualmente em Beta e pode mudar."
       },
       "conversation_starters_pdp": {
         "label": "Perguntas sugeridas por IA",

--- a/src/tests/components/AppGrid.spec.js
+++ b/src/tests/components/AppGrid.spec.js
@@ -89,7 +89,7 @@ describe('AppGrid', () => {
       const configuredApp = {
         uuid: 'app-uuid-123',
         code: 'wwc',
-        name: 'Weni Web Chat',
+        name: 'Shopping Assistant',
         generic: false,
         icon: null,
         summary: 'weniWebChat.data.summary',

--- a/src/tests/components/config/channels/WWC/Config.spec.js
+++ b/src/tests/components/config/channels/WWC/Config.spec.js
@@ -107,7 +107,7 @@ describe('wwcConfig Component', () => {
   describe('rendering', () => {
     it('should render the component correctly', () => {
       expect(wrapper.find('.app-config-wwc').exists()).toBe(true);
-      expect(wrapper.find('.app-config-wwc__header__title').text()).toBe('Test App');
+      expect(wrapper.find('.app-config-wwc__header__title').text()).toBe('Shopping Assistant');
     });
 
     it('should render AppearanceTab component', () => {

--- a/src/tests/utils/apps.spec.js
+++ b/src/tests/utils/apps.spec.js
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+import { getAppDisplayName, appMatchesSearch } from '@/utils/apps';
+
+describe('apps utils', () => {
+  const t = vi.fn((key) => {
+    if (key === 'weniWebChat.data.name') return 'Shopping Assistant';
+    return key;
+  });
+
+  describe('getAppDisplayName', () => {
+    it('returns localized name for wwc apps', () => {
+      expect(getAppDisplayName({ code: 'wwc', name: 'Weni Web Chat' }, t)).toBe(
+        'Shopping Assistant',
+      );
+    });
+
+    it('returns api name for non-wwc apps', () => {
+      expect(getAppDisplayName({ code: 'telegram', name: 'Telegram' }, t)).toBe('Telegram');
+    });
+
+    it('returns empty string when app is undefined', () => {
+      expect(getAppDisplayName(undefined, t)).toBe('');
+    });
+  });
+
+  describe('appMatchesSearch', () => {
+    const wwcApp = { code: 'wwc', name: 'Weni Web Chat' };
+
+    it('matches display name', () => {
+      expect(appMatchesSearch(wwcApp, 'shopping assistant', t)).toBe(true);
+    });
+
+    it('matches legacy api name', () => {
+      expect(appMatchesSearch(wwcApp, 'weni web chat', t)).toBe(true);
+    });
+
+    it('returns false when search term does not match', () => {
+      expect(appMatchesSearch(wwcApp, 'telegram', t)).toBe(false);
+    });
+
+    it('returns true for empty search term', () => {
+      expect(appMatchesSearch(wwcApp, '  ', t)).toBe(true);
+    });
+  });
+});

--- a/src/tests/views/MyApps.spec.js
+++ b/src/tests/views/MyApps.spec.js
@@ -8,7 +8,7 @@ import { app_type } from '@/stores/modules/appType/appType.store';
 const mockApp = {
   uuid: 'app-uuid-123',
   code: 'wwc',
-  name: 'Weni Web Chat',
+  name: 'Shopping Assistant',
   generic: false,
   icon: null,
   summary: 'weniWebChat.data.summary',

--- a/src/tests/views/mocks/appMock.js
+++ b/src/tests/views/mocks/appMock.js
@@ -1,7 +1,7 @@
 const singleApp = {
   uuid: '123',
   code: 'wwc',
-  name: 'Weni Web Chat',
+  name: 'Shopping Assistant',
   description:
     'Ullamco occaecat et id cillum. Amet exercitation nisi amet fugiat mollit minim est. Officia in enim amet ipsum Lorem velit sint pariatur sunt magna cupidatat. Magna non ea qui nisi ut.s',
   summary: 'Ullamco occaecat et id cillum.',
@@ -39,7 +39,7 @@ const singleApp = {
 const communicationApps = [
   {
     id: 1,
-    name: 'Weni Web Chat',
+    name: 'Shopping Assistant',
     description:
       'Ullamco occaecat et id cillum. Amet exercitation nisi amet fugiat mollit minim est. Officia in enim amet ipsum Lorem velit sint pariatur sunt magna cupidatat. Magna non ea qui nisi ut.s',
     usersCount: 25,
@@ -141,7 +141,7 @@ const attendanceApps = [
 const configuredApps = [
   {
     code: 'wwc',
-    name: 'Weni Web Chat',
+    name: 'Shopping Assistant',
     description:
       'Ullamco occaecat et id cillum. Amet exercitation nisi amet fugiat mollit minim est. Officia in enim amet ipsum Lorem velit sint pariatur sunt magna cupidatat. Magna non ea qui nisi ut.s',
     summary: 'Ullamco occaecat et id cillum.',

--- a/src/utils/apps.js
+++ b/src/utils/apps.js
@@ -1,0 +1,16 @@
+export function getAppDisplayName(app, t) {
+  if (app?.code === 'wwc') {
+    return t('weniWebChat.data.name');
+  }
+  return app?.name ?? '';
+}
+
+export function appMatchesSearch(app, searchTerm, t) {
+  const term = searchTerm.trim().toLowerCase();
+  if (!term) return true;
+
+  const displayName = getAppDisplayName(app, t).toLowerCase();
+  const apiName = (app?.name ?? '').toLowerCase();
+
+  return displayName.includes(term) || apiName.includes(term);
+}

--- a/src/views/AppDetails/index.vue
+++ b/src/views/AppDetails/index.vue
@@ -47,6 +47,7 @@
   import { app_type } from '@/stores/modules/appType/appType.store';
   import { mapActions, mapState } from 'pinia';
   import millify from 'millify';
+  import { getAppDisplayName } from '@/utils/apps';
 
   export default {
     name: 'AppPage',
@@ -128,7 +129,7 @@
         ];
         if (this.currentAppType?.name) {
           history.push({
-            name: this.currentAppType.name,
+            name: getAppDisplayName(this.currentAppType, this.$t.bind(this)),
             path: '',
           });
         }

--- a/src/views/Discovery/index.vue
+++ b/src/views/Discovery/index.vue
@@ -62,6 +62,7 @@
   import { externals_store } from '@/stores/modules/appType/externals/externals.store';
   import { ecommerce_store } from '@/stores/modules/appType/ecommerce/ecommerce.store';
   import unnnic from '@weni/unnnic-system';
+  import { getAppDisplayName, appMatchesSearch } from '@/utils/apps';
   export default {
     name: 'Discovery',
     components: {
@@ -102,11 +103,11 @@
         const allApps = [...this.allAppTypes, ...this.externalServicesList];
 
         const filtered = allApps.filter((app) => {
-          return app.name.toLowerCase().includes(this.searchTerm.trim().toLowerCase());
+          return appMatchesSearch(app, this.searchTerm, this.$t.bind(this));
         });
 
         return filtered.map((app) => {
-          return app.name;
+          return getAppDisplayName(app, this.$t.bind(this));
         });
       },
       filteredApps() {
@@ -115,7 +116,7 @@
         if (!this.searchTerm || !this.searchTerm.trim()) return this.allAppTypes;
 
         return this.allAppTypes.filter((app) => {
-          return app.name.toLowerCase().includes(this.searchTerm.trim().toLowerCase());
+          return appMatchesSearch(app, this.searchTerm, this.$t.bind(this));
         });
       },
       filteredExternalServices() {
@@ -124,7 +125,7 @@
         if (!this.searchTerm || !this.searchTerm.trim()) return this.externalServicesList;
 
         return this.externalServicesList.filter((app) => {
-          return app.name.toLowerCase().includes(this.searchTerm.trim().toLowerCase());
+          return appMatchesSearch(app, this.searchTerm, this.$t.bind(this));
         });
       },
       filteredEcommerceApps() {
@@ -133,7 +134,7 @@
         if (!this.searchTerm || !this.searchTerm.trim()) return this.ecommerceAppsList;
 
         return this.ecommerceAppsList.filter((app) => {
-          return app.name.toLowerCase().includes(this.searchTerm.trim().toLowerCase());
+          return appMatchesSearch(app, this.searchTerm, this.$t.bind(this));
         });
       },
       hasAnyVisibleApp() {

--- a/src/views/MyApps/index.vue
+++ b/src/views/MyApps/index.vue
@@ -68,6 +68,7 @@
   import { my_apps } from '@/stores/modules/myApps.store';
   import { app_type } from '@/stores/modules/appType/appType.store';
   import { useEventStore } from '@/stores/event.store';
+  import { getAppDisplayName, appMatchesSearch } from '@/utils/apps';
 
   export default {
     name: 'Apps',
@@ -114,7 +115,9 @@
         const filtered = this.filterByName(allApps, this.searchTerm);
 
         return filtered.map((app) => {
-          let name = app.generic ? app.config.channel_name : app.name;
+          let name = app.generic
+            ? app.config.channel_name
+            : getAppDisplayName(app, this.$t.bind(this));
           if (app.config?.title) {
             name += ` - ${app.config?.title}`;
           }
@@ -189,11 +192,17 @@
       },
       filterByName(appList, search) {
         return appList.filter((app) => {
-          const appMainName = app.generic ? app.config.channel_name : app.name;
+          const appMainName = app.generic
+            ? app.config.channel_name
+            : getAppDisplayName(app, this.$t.bind(this));
           const appName = app.config?.title || app.config?.channel_name;
 
           const name = appMainName + appName;
-          return name.toLowerCase().includes(search.toLowerCase());
+          const matchesName = name.toLowerCase().includes(search.toLowerCase());
+          const matchesLegacyName =
+            !app.generic && appMatchesSearch(app, search, this.$t.bind(this));
+
+          return matchesName || matchesLegacyName;
         });
       },
       fetchCategories() {


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* [ ] Bugfix
* [ ] Feature
* [x] Refactoring (no functional changes, no api changes)
* [ ] Code style update (formatting, local variables)
* [x] Tests
* [ ] Other

### Motivation and Context
The WWC integration was rebranded from "Web Chat" / "Webchat" to **Shopping Assistant**, but several user-facing strings still showed the old name. Some labels came from locale files; the app title still came from the API as `"Weni Web Chat"`.

This change aligns all visible UI copy with the new product name without changing internal identifiers (`wwc`, `weniWebChat`, script URLs, etc.).

### Summary of Changes
- Updated locale strings in `en.json`, `pt_br.json`, and `es_es.json`:
  - Added `weniWebChat.data.name`: `"Shopping Assistant"`
  - Replaced remaining **Web Chat**, **Webchat**, **Web Channel**, and **Canal Web** references in summaries, descriptions, config copy, script tutorial, and preference helpers
- Added `src/utils/apps.js` with:
  - `getAppDisplayName()` — returns `"Shopping Assistant"` for `wwc` apps instead of the API name
  - `appMatchesSearch()` — supports search by both the new and legacy API names
- Wired display name override into:
  - `AppGrid` (card titles)
  - `AppDetailsHeader` (details page title)
  - `WWC/Config.vue` (config modal header)
  - `AppDetails` (breadcrumb)
  - `Discovery` and `MyApps` (search/filter)
- Updated test mocks and added `src/tests/utils/apps.spec.js`