### PR TITLE
Remove Omie configuration description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+3.14.1
+----------
+`2026-07-08 · 2 🔧`
+
+### 🔧 Improvements
+- Remove Omie configuration description
+- Update WebChat title character limit to match backend validation
+
 3.14.0
 ----------
 `2026-06-22 · 1 🔧`

--- a/src/components/config/channels/WWC/Config.vue
+++ b/src/components/config/channels/WWC/Config.vue
@@ -273,7 +273,7 @@
         return t('errors.empty_input');
       }
       if (value.length > TITLE_MAX_LENGTH) {
-        return `By default, the maximum is ${TITLE_MAX_LENGTH} characters.`;
+        return t('weniWebChat.config.TitleInput.max_length', { max: TITLE_MAX_LENGTH });
       }
     }
     return null;

--- a/src/components/config/channels/WWC/Config.vue
+++ b/src/components/config/channels/WWC/Config.vue
@@ -151,7 +151,12 @@
   import { dataUrlToFile, toBase64 } from '@/utils/files';
   import removeEmpty from '@/utils/clean';
   import { getAppDisplayName } from '@/utils/apps';
-  import { DEFAULT_COLOR, formatContactTimeout, parseContactTimeout } from './constants';
+  import {
+    DEFAULT_COLOR,
+    TITLE_MAX_LENGTH,
+    formatContactTimeout,
+    parseContactTimeout,
+  } from './constants';
   import AppearanceTab from './components/tabs/AppearanceTab.vue';
   import PreferencesTab from './components/tabs/PreferencesTab.vue';
   import VoiceModeTab from './components/tabs/VoiceModeTab.vue';
@@ -267,8 +272,8 @@
       if (!(value && value.trim())) {
         return t('errors.empty_input');
       }
-      if (value.length > 20) {
-        return 'By default, the maximum is 20 characters.';
+      if (value.length > TITLE_MAX_LENGTH) {
+        return `By default, the maximum is ${TITLE_MAX_LENGTH} characters.`;
       }
     }
     return null;

--- a/src/components/config/channels/WWC/components/tabs/AppearanceTab.vue
+++ b/src/components/config/channels/WWC/components/tabs/AppearanceTab.vue
@@ -225,7 +225,7 @@
       return t('errors.empty_input');
     }
     if (title.value.length > TITLE_MAX_LENGTH) {
-      return `By default, the maximum is ${TITLE_MAX_LENGTH} characters.`;
+      return t('weniWebChat.config.TitleInput.max_length', { max: TITLE_MAX_LENGTH });
     }
     return '';
   });

--- a/src/components/config/channels/WWC/components/tabs/AppearanceTab.vue
+++ b/src/components/config/channels/WWC/components/tabs/AppearanceTab.vue
@@ -114,7 +114,7 @@
   import { useI18n } from 'vue-i18n';
   import ColorPicker from '@/components/ColorPicker/index.vue';
   import { useFileUpload } from '@/composables/useFileUpload';
-  import { APPEARANCE_FIELDS } from '../../constants';
+  import { APPEARANCE_FIELDS, TITLE_MAX_LENGTH } from '../../constants';
   import { dataUrlToFile } from '@/utils/files';
 
   const { t } = useI18n();
@@ -224,8 +224,8 @@
     if (!title.value?.trim()) {
       return t('errors.empty_input');
     }
-    if (title.value.length > 25) {
-      return 'By default, the maximum is 25 characters.';
+    if (title.value.length > TITLE_MAX_LENGTH) {
+      return `By default, the maximum is ${TITLE_MAX_LENGTH} characters.`;
     }
     return '';
   });

--- a/src/components/config/channels/WWC/constants.js
+++ b/src/components/config/channels/WWC/constants.js
@@ -1,5 +1,7 @@
 export const DEFAULT_COLOR = '#009E96';
 
+export const TITLE_MAX_LENGTH = 1000;
+
 export const WEBCHAT_SCRIPT_URLS = {
   v1: 'https://storage.googleapis.com/push-webchat/wwc-latest.js',
   v2: 'https://cdn.cloud.weni.ai/webchat-latest.umd.js',

--- a/src/components/config/external/omie/Config.vue
+++ b/src/components/config/external/omie/Config.vue
@@ -7,7 +7,6 @@
         </div>
         <div class="app-config-omie__header__title__name">{{ app.name }}</div>
       </div>
-      <span class="app-config-omie__header__description" v-html="$t('omie.config.description')" />
     </div>
 
     <div class="app-config-omie__settings__content">
@@ -175,22 +174,6 @@
           color: $unnnic-color-neutral-darkest;
 
           margin-left: $unnnic-inline-sm;
-        }
-      }
-
-      &__description {
-        margin-top: $unnnic-inline-sm;
-        font-family: $unnnic-font-family-secondary;
-        font-weight: $unnnic-font-weight-regular;
-        font-size: $unnnic-font-size-body-gt;
-        line-height: $unnnic-font-size-body-gt + $unnnic-line-height-md;
-        color: $unnnic-color-neutral-cloudy;
-
-        ::v-deep {
-          a {
-            font-weight: $unnnic-font-weight-bold;
-            color: $unnnic-color-neutral-cloudy;
-          }
         }
       }
     }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -230,6 +230,7 @@
       "initPayloadToolTip": "When opening the chat on your website, a trigger with this value will be called automatically to start a chosen flow. You can configure it on Studio.",
       "TitleInput": {
         "label": "Chat Title",
+        "max_length": "By default, the maximum is {max} characters.",
         "placeholder": "Ex.: Name of your chatbot"
       },
       "SubtitleInput": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -995,7 +995,6 @@
       "description": "If you have a CRM at Omie, you can integrate with the VTEX Agentic CX Platform and automate actions in your CRM through your chatbot.<br><br>By integrating the VTEX Agentic CX platform with your CRM on Omie you will be able to perform actions such as:<br><br>- Include Opportunities in the CRM<br>- Search Title and Releases<br>- List customers<br><br>Here in the Integrations module, you must perform the Integration with Omie providing the API Key and API Secret data and then perform the integration.<br>After that, just go to the flows module, create a flow and then you will have a card available called External Services, in which you will be able to perform all the actions with Omie's CRM mentioned here."
     },
     "config": {
-      "description": "Learn more about integrating with Omie <a href=\"https://ajuda.omie.com.br/pt-BR/articles/499061-obtendo-a-chave-de-acesso-para-integracoes-de-api\" target=\"_blank\" class=\"link\">here</a>",
       "connect": "Connect",
       "tabs": {
         "config": {

--- a/src/locales/es_es.json
+++ b/src/locales/es_es.json
@@ -991,7 +991,6 @@
       "description": "Si tienes un CRM en Omie, puedes integrarte con la Plataforma VTEX Agentic CX y automatizar acciones en tu CRM a través de tu chatbot.<br><br>Al integrar la plataforma VTEX Agentic CX con tu CRM en Omie podrás realizar acciones como :<br><br>- Incluir Oportunidades en el CRM<br>- Buscar Título y Lanzamientos<br>- Listar clientes<br><br>Aquí en el módulo de Integraciones, debes realizar la Integración con Omie proporcionando la API Key y datos secretos de API y luego realice la integración.<br>Después de eso, simplemente vaya al módulo de flujos, cree un flujo y luego tendrá una tarjeta disponible llamada Servicios externos, en la que podrá realizar todas las acciones con CRM de Omie mencionado aquí."
     },
     "config": {
-      "description": "Obtenga más información sobre la integración con Omie <a href=\"https://ajuda.omie.com.br/pt-BR/articles/499061-obtendo-a-chave-de-acesso-para-integracoes-de-api\" target=\"_blank\" class=\"link\">aquí</a>",
       "connect": "Conectar",
       "tabs": {
         "config": {

--- a/src/locales/es_es.json
+++ b/src/locales/es_es.json
@@ -230,6 +230,7 @@
       "initPayloadToolTip": "Al abrir el chat en su sitio web, un disparador con este valor será llamado automáticamente para iniciar un flujo elegido. Puede configurarlo en Studio.",
       "TitleInput": {
         "label": "Título del chat",
+        "max_length": "Por defecto, el máximo es {max} caracteres.",
         "placeholder": "Ej.: Nombre de su chatbot"
       },
       "SubtitleInput": {

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -230,6 +230,7 @@
       "initPayloadToolTip": "Ao abrir o chat em seu site, uma trigger com este valor sera chamada automaticamente para iniciar um fluxo escolhido. Voce pode configura-la em Estúdio.",
       "TitleInput": {
         "label": "Título do Chat",
+        "max_length": "Por padrão, o máximo é {max} caracteres.",
         "placeholder": "Ex.: Nome do seu chatbot"
       },
       "SubtitleInput": {

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -995,7 +995,6 @@
       "description": "Se você possui um CRM na Omie, você pode integrar com a Plataforma VTEX Agentic CX e automatizar ações no seu CRM através do seu chatbot.<br><br>Integrando a plataforma VTEX Agentic CX com seu CRM na Omie você será capaz de realizar ações como:<br><br>- Incluir Oportunidades no CRM<br>- Pesquisar Titulo e Lançamentos<br>- Listar cliente<br><br>Por aqui no módulo de Integrações, você deve realizar a Integração com a Omie fornecendo os dados de API Key e API Secret e então realizar a integração.<br>Após isso, basta ir no módulo de flows, criar um fluxo e então você terá um card disponível chamada para Serviços Externos, nele você será capaz de realizar todas as ações com o CRM da Omie mencionadas aqui."
     },
     "config": {
-      "description": "Saiba mais sobre como integrar com a Omie <a href=\"https://ajuda.omie.com.br/pt-BR/articles/499061-obtendo-a-chave-de-acesso-para-integracoes-de-api\" target=\"_blank\" class=\"link\">aqui</a>",
       "connect": "Conectar",
       "tabs": {
         "config": {

--- a/src/locales/ro_ro.json
+++ b/src/locales/ro_ro.json
@@ -230,6 +230,7 @@
       "initPayloadToolTip": "La deschiderea chat-ului pe site-ul dvs., un trigger cu această valoare va fi apelat automat pentru a începe un flux ales. Puteți configura în Studio.",
       "TitleInput": {
         "label": "Titlu chat",
+        "max_length": "În mod implicit, maximul este de {max} caractere.",
         "placeholder": "Ex.: Numele chatbot-ului dvs."
       },
       "SubtitleInput": {

--- a/src/tests/components/config/channels/WWC/Config.spec.js
+++ b/src/tests/components/config/channels/WWC/Config.spec.js
@@ -345,11 +345,11 @@ describe('wwcConfig Component', () => {
       );
     });
 
-    it('should show error alert if title exceeds 20 characters', async () => {
+    it('should show error alert if title exceeds 1000 characters', async () => {
       const alertSpy = vi.spyOn(unnnic, 'unnnicCallAlert');
 
       const appearanceTab = wrapper.findComponent({ name: 'AppearanceTab' });
-      await appearanceTab.vm.$emit('update:title', 'This title is way too long');
+      await appearanceTab.vm.$emit('update:title', 'a'.repeat(1001));
       await appearanceTab.vm.$emit('save');
 
       expect(alertSpy).toHaveBeenCalledWith(

--- a/src/tests/components/config/channels/WWC/constants.spec.js
+++ b/src/tests/components/config/channels/WWC/constants.spec.js
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   DEFAULT_COLOR,
+  TITLE_MAX_LENGTH,
   WEBCHAT_SCRIPT_URLS,
   TIME_BETWEEN_MESSAGES_OPTIONS,
   APPEARANCE_FIELDS,
@@ -12,6 +13,12 @@ import {
 } from '@/components/config/channels/WWC/constants';
 
 describe('WWC constants', () => {
+  describe('TITLE_MAX_LENGTH', () => {
+    it('should be 1000 characters', () => {
+      expect(TITLE_MAX_LENGTH).toBe(1000);
+    });
+  });
+
   describe('DEFAULT_COLOR', () => {
     it('should be the correct default color', () => {
       expect(DEFAULT_COLOR).toBe('#009E96');

--- a/src/tests/components/config/channels/WWC/tabs/AppearanceTab.spec.js
+++ b/src/tests/components/config/channels/WWC/tabs/AppearanceTab.spec.js
@@ -175,8 +175,8 @@ describe('AppearanceTab', () => {
       expect(input.attributes('type')).toBe('error');
     });
 
-    it('should show error for title exceeding 25 characters', async () => {
-      wrapper = createWrapper({ initialTitle: 'This is a very long title exceeding limit' });
+    it('should show error for title exceeding 1000 characters', async () => {
+      wrapper = createWrapper({ initialTitle: 'a'.repeat(1001) });
       await wrapper.vm.$nextTick();
       const input = wrapper.find('unnnic-input-stub');
       expect(input.attributes('type')).toBe('error');
@@ -189,8 +189,8 @@ describe('AppearanceTab', () => {
       expect(input.attributes('type')).toBe('normal');
     });
 
-    it('should show normal type for title with exactly 25 characters', async () => {
-      wrapper = createWrapper({ initialTitle: '1234567890123456789012345' });
+    it('should show normal type for title with exactly 1000 characters', async () => {
+      wrapper = createWrapper({ initialTitle: 'a'.repeat(1000) });
       await wrapper.vm.$nextTick();
       const input = wrapper.find('unnnic-input-stub');
       expect(input.attributes('type')).toBe('normal');


### PR DESCRIPTION
## Description
### Type of Change
* * [ ] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [x] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
The Omie integration config modal displayed a link to external Omie documentation (`ajuda.omie.com.br`) in the header. This change removes that reference to avoid pointing users to third-party documentation from the VTEX Agentic CX integrations UI.

### Summary of Changes
- Removed the description block from the Omie config modal header in `src/components/config/external/omie/Config.vue`
- Removed unused SCSS styles for the header description (`&__description`)
- Removed the `omie.config.description` translation key from:
  - `src/locales/en.json`
  - `src/locales/pt_br.json`
  - `src/locales/es_es.json`

The Omie integration configuration flow remains unchanged: users can still connect using App Key and App Secret.