### PR TITLE
Add and update translations from PR#591

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -230,7 +230,7 @@
       "initPayloadToolTip": "When opening the chat on your site, a trigger with this value will automatically fire to start the selected flow. You can configure it in Studio.",
       "TitleInput": {
         "label": "Chat title",
-        "max_length": "By default, the maximum is {max} characters.",
+        "max_length": "The maximum length is {max} characters",
         "placeholder": "Ex.: Your chatbot's name"
       },
       "SubtitleInput": {

--- a/src/locales/es_es.json
+++ b/src/locales/es_es.json
@@ -230,7 +230,7 @@
       "initPayloadToolTip": "Al abrir el chat en tu sitio web, se disparará automáticamente un trigger con este valor para iniciar el flujo seleccionado. Puedes configurarlo en Studio.",
       "TitleInput": {
         "label": "Título del chat",
-        "max_length": "Por defecto, el máximo es {max} caracteres.",
+        "max_length": "La longitud máxima es de {max} caracteres",
         "placeholder": "Ej.: Nombre de tu chatbot"
       },
       "SubtitleInput": {

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -230,7 +230,7 @@
       "initPayloadToolTip": "Ao abrir o chat no seu site, um trigger com este valor será disparado automaticamente para iniciar o fluxo escolhido. Você pode configurá-lo em Estúdio.",
       "TitleInput": {
         "label": "Título do chat",
-        "max_length": "Por padrão, o máximo é {max} caracteres.",
+        "max_length": "O tamanho máximo é de {max} caracteres",
         "placeholder": "Ex.: Nome do seu chatbot"
       },
       "SubtitleInput": {

--- a/src/locales/ro_ro.json
+++ b/src/locales/ro_ro.json
@@ -230,7 +230,7 @@
       "initPayloadToolTip": "Când deschizi chatul pe site, un declanșator cu această valoare va porni automat pentru a începe fluxul selectat. Îl poți configura în Studio.",
       "TitleInput": {
         "label": "Titlul chatului",
-        "max_length": "În mod implicit, maximul este de {max} caractere.",
+        "max_length": "Lungimea maximă este de {max} caractere",
         "placeholder": "Ex.: Numele chatbot-ului tău"
       },
       "SubtitleInput": {


### PR DESCRIPTION
Add and update translations from [PR#591](https://github.com/weni-ai/weni-integrations-webapp/pull/591). Tracked in [LOC-26968](https://vtex-dev.atlassian.net/browse/LOC-26968).

Updates `weniWebChat.config.TitleInput.max_length` in en, pt_br, es_es, and ro_ro.