### PR TITLE
✨ Connect New WhatsApp Account modal on Meta credit allocation error

### DIFF
--- a/src/components/config/channels/whatsapp/ConnectNewWhatsAppAccountModal.vue
+++ b/src/components/config/channels/whatsapp/ConnectNewWhatsAppAccountModal.vue
@@ -1,0 +1,71 @@
+<template>
+  <unnnic-modal
+    class="connect-new-whatsapp-account-modal"
+    :showModal="show"
+    :text="$t('WhatsAppCloud.setup.connect_new_account.title')"
+    scheme="feedback-red"
+    modal-icon="alert-circle-1"
+    @close="handleClose"
+    @click.stop
+  >
+    <template #message>
+      <div
+        class="connect-new-whatsapp-account-modal__description"
+        v-html="$t('WhatsAppCloud.setup.connect_new_account.description')"
+      />
+    </template>
+    <template #options>
+      <unnnic-button
+        type="primary"
+        size="large"
+        :text="$t('WhatsAppCloud.setup.connect_new_account.try_again')"
+        @click="handleTryAgain"
+      />
+    </template>
+  </unnnic-modal>
+</template>
+
+<script>
+  export default {
+    name: 'ConnectNewWhatsAppAccountModal',
+    props: {
+      show: {
+        type: Boolean,
+        default: false,
+      },
+    },
+    emits: ['close', 'try-again'],
+    methods: {
+      handleClose() {
+        this.$emit('close');
+      },
+      handleTryAgain() {
+        this.$emit('try-again');
+        this.$emit('close');
+      },
+    },
+  };
+</script>
+
+<style lang="scss" scoped>
+  .connect-new-whatsapp-account-modal {
+    cursor: default;
+
+    &__description {
+      text-align: left;
+
+      :deep(ol) {
+        padding-left: $unnnic-spacing-inline-md;
+        margin: 0;
+      }
+
+      :deep(li) {
+        margin-top: $unnnic-spacing-stack-nano;
+      }
+
+      :deep(b) {
+        font-weight: $unnnic-font-weight-bold;
+      }
+    }
+  }
+</style>

--- a/src/components/config/channels/whatsapp/ConnectNewWhatsAppAccountModal.vue
+++ b/src/components/config/channels/whatsapp/ConnectNewWhatsAppAccountModal.vue
@@ -1,28 +1,31 @@
 <template>
-  <unnnic-modal
+  <unnnic-dialog
     class="connect-new-whatsapp-account-modal"
-    :showModal="show"
-    :text="$t('WhatsAppCloud.setup.connect_new_account.title')"
-    scheme="feedback-red"
-    modal-icon="alert-circle-1"
-    @close="handleClose"
-    @click.stop
+    :open="show"
+    @update:open="handleOpenUpdate"
   >
-    <template #message>
+    <unnnic-dialog-content size="medium">
+      <unnnic-dialog-header type="warning">
+        <unnnic-dialog-title>
+          {{ $t('WhatsAppCloud.setup.connect_new_account.title') }}
+        </unnnic-dialog-title>
+      </unnnic-dialog-header>
+
       <section
         class="connect-new-whatsapp-account-modal__description"
         v-html="$t('WhatsAppCloud.setup.connect_new_account.description')"
       />
-    </template>
-    <template #options>
-      <unnnic-button
-        type="primary"
-        size="large"
-        :text="$t('WhatsAppCloud.setup.connect_new_account.try_again')"
-        @click="handleTryAgain"
-      />
-    </template>
-  </unnnic-modal>
+
+      <unnnic-dialog-footer>
+        <unnnic-button
+          type="primary"
+          size="large"
+          :text="$t('WhatsAppCloud.setup.connect_new_account.try_again')"
+          @click="handleTryAgain"
+        />
+      </unnnic-dialog-footer>
+    </unnnic-dialog-content>
+  </unnnic-dialog>
 </template>
 
 <script setup>
@@ -35,8 +38,10 @@
 
   const emit = defineEmits(['close', 'try-again']);
 
-  function handleClose() {
-    emit('close');
+  function handleOpenUpdate(open) {
+    if (!open) {
+      emit('close');
+    }
   }
 
   function handleTryAgain() {
@@ -51,6 +56,8 @@
 
     &__description {
       text-align: left;
+      padding: $unnnic-spacing-md;
+      color: $unnnic-color-fg-base;
 
       :deep(ol) {
         padding-left: $unnnic-spacing-inline-md;

--- a/src/components/config/channels/whatsapp/ConnectNewWhatsAppAccountModal.vue
+++ b/src/components/config/channels/whatsapp/ConnectNewWhatsAppAccountModal.vue
@@ -9,7 +9,7 @@
     @click.stop
   >
     <template #message>
-      <div
+      <section
         class="connect-new-whatsapp-account-modal__description"
         v-html="$t('WhatsAppCloud.setup.connect_new_account.description')"
       />

--- a/src/components/config/channels/whatsapp/ConnectNewWhatsAppAccountModal.vue
+++ b/src/components/config/channels/whatsapp/ConnectNewWhatsAppAccountModal.vue
@@ -25,26 +25,24 @@
   </unnnic-modal>
 </template>
 
-<script>
-  export default {
-    name: 'ConnectNewWhatsAppAccountModal',
-    props: {
-      show: {
-        type: Boolean,
-        default: false,
-      },
+<script setup>
+  defineProps({
+    show: {
+      type: Boolean,
+      default: false,
     },
-    emits: ['close', 'try-again'],
-    methods: {
-      handleClose() {
-        this.$emit('close');
-      },
-      handleTryAgain() {
-        this.$emit('try-again');
-        this.$emit('close');
-      },
-    },
-  };
+  });
+
+  const emit = defineEmits(['close', 'try-again']);
+
+  function handleClose() {
+    emit('close');
+  }
+
+  function handleTryAgain() {
+    emit('try-again');
+    emit('close');
+  }
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/config/channels/whatsapp/Setup.vue
+++ b/src/components/config/channels/whatsapp/Setup.vue
@@ -35,6 +35,12 @@
         </div>
       </template>
     </unnnic-modal>
+
+    <ConnectNewWhatsAppAccountModal
+      :show="showConnectNewAccountModal"
+      @close="showConnectNewAccountModal = false"
+      @try-again="handleConnectNewAccountTryAgain"
+    />
   </div>
 </template>
 
@@ -44,14 +50,17 @@
   import { auth_store } from '@/stores/modules/auth.store';
   import unnnic from '@weni/unnnic-system';
   import LoadingButton from '../../../LoadingButton/index.vue';
+  import ConnectNewWhatsAppAccountModal from './ConnectNewWhatsAppAccountModal.vue';
   import getEnv from '@/utils/env';
   import { initFacebookSdk } from '@/utils/plugins/fb';
   import { captureSentryManualError } from '@/utils/sentry';
+  import { isMetaCreditAllocationError } from '@/utils/metaError';
 
   export default {
     name: 'WhatsAppSetup',
     components: {
       LoadingButton,
+      ConnectNewWhatsAppAccountModal,
     },
     props: {
       app: {
@@ -64,6 +73,7 @@
         phoneNumberId: null,
         wabaId: null,
         onLogin: false,
+        showConnectNewAccountModal: false,
       };
     },
     async mounted() {
@@ -229,9 +239,13 @@
           const res = await this.configurePhoneNumber({ data });
 
           if (this.errorCloudConfigure) {
-            this.callErrorModal({
-              text: this.$t('WhatsAppCloud.config.configure_phone_number.error'),
-            });
+            if (isMetaCreditAllocationError(this.errorCloudConfigure)) {
+              this.showConnectNewAccountModal = true;
+            } else {
+              this.callErrorModal({
+                text: this.$t('WhatsAppCloud.config.configure_phone_number.error'),
+              });
+            }
 
             this.sendToSentry('Error trying to create WAC channel', {
               data: data,
@@ -245,6 +259,10 @@
             this.$router.replace('/apps/my');
           }
         }
+      },
+      handleConnectNewAccountTryAgain() {
+        this.showConnectNewAccountModal = false;
+        this.startFacebookLogin();
       },
       closePopUp() {
         this.$emit('closePopUp');

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -876,6 +876,11 @@
     "setup": {
       "continue": "Continue",
       "connect": "Connect",
+      "connect_new_account": {
+        "description": "The WhatsApp Business Account you selected is already set up for billing with another system, so your number can't be connected through it.<br /><br />Create a <b>new WhatsApp Business Account</b> and your number will connect successfully. This works no matter where your business is located.<br /><br /><ol><li>Select <b>Try again</b> below.</li><li>When WhatsApp asks which account to use, choose <b>Create a new WhatsApp Business Account</b>.</li><li>Follow the setup steps to finish.</li></ol>",
+        "title": "Connect new WhatsApp account",
+        "try_again": "Try again"
+      },
       "description": "Follow the steps to integrate with WhatsApp"
     },
     "config": {

--- a/src/locales/es_es.json
+++ b/src/locales/es_es.json
@@ -876,6 +876,11 @@
     "setup": {
       "continue": "Continuar",
       "connect": "Conectar",
+      "connect_new_account": {
+        "description": "La cuenta de persona jurídica de WhatsApp seleccionada ya está configurada para facturación con otro sistema, por lo que tu número no puede conectarse a través de ella.<br /><br />Crea una <b>nueva cuenta de persona jurídica de WhatsApp</b> y tu número se conectará correctamente. Funciona sin importar dónde esté ubicado tu negocio.<br /><br /><ol><li>Selecciona <b>Intentar nuevamente</b> a continuación.</li><li>Cuando WhatsApp pregunte qué cuenta usar, selecciona <b>Crear una nueva cuenta de persona jurídica de WhatsApp</b>.</li><li>Sigue los pasos de configuración para finalizar.</li></ol>",
+        "title": "Conectar nueva cuenta de WhatsApp",
+        "try_again": "Intentar nuevamente"
+      },
       "description": "Sigue los pasos para integrar WhatsApp"
     },
     "config": {

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -876,6 +876,11 @@
     "setup": {
       "continue": "Continuar",
       "connect": "Conectar",
+      "connect_new_account": {
+        "description": "A conta de pessoa jurídica do WhatsApp selecionada já está configurada para cobrança com outro sistema, então seu número não pode ser conectado através dela.<br /><br />Crie uma <b>nova conta de pessoa jurídica do WhatsApp</b> e seu número será conectado com sucesso. Isso funciona independentemente de onde seu negócio está localizado.<br /><br /><ol><li>Selecione <b>Tentar novamente</b> abaixo.</li><li>Quando o WhatsApp perguntar qual conta usar, escolha <b>Criar uma nova conta de pessoa jurídica do WhatsApp</b>.</li><li>Siga as etapas de configuração para concluir.</li></ol>",
+        "title": "Conectar nova conta do WhatsApp",
+        "try_again": "Tentar novamente"
+      },
       "description": "Siga os passos para integrar com o WhatsApp"
     },
     "config": {

--- a/src/locales/ro_ro.json
+++ b/src/locales/ro_ro.json
@@ -876,6 +876,11 @@
     "setup": {
       "continue": "Continuă",
       "connect": "Conectare",
+      "connect_new_account": {
+        "description": "Contul WhatsApp Business selectat este deja configurat pentru facturare cu un alt sistem, astfel numărul tău nu poate fi conectat prin el.<br /><br />Creează un <b>cont WhatsApp Business nou</b> și numărul tău se va conecta cu succes. Funcționează indiferent de locația afacerii tale.<br /><br /><ol><li>Selectează <b>Încearcă din nou</b> mai jos.</li><li>Când WhatsApp te întreabă ce cont să folosești, alege <b>Creează un cont WhatsApp Business nou</b>.</li><li>Urmează pașii de configurare pentru a finaliza.</li></ol>",
+        "title": "Conectează un cont WhatsApp nou",
+        "try_again": "Încearcă din nou"
+      },
       "description": "Urmează pașii pentru a realiza integrarea cu WhatsApp"
     },
     "config": {

--- a/src/tests/components/config/channels/whatsapp/ConnectNewWhatsAppAccountModal.spec.js
+++ b/src/tests/components/config/channels/whatsapp/ConnectNewWhatsAppAccountModal.spec.js
@@ -1,0 +1,159 @@
+import { mount } from '@vue/test-utils';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import ConnectNewWhatsAppAccountModal from '@/components/config/channels/whatsapp/ConnectNewWhatsAppAccountModal.vue';
+import i18n from '@/utils/plugins/i18n';
+
+const DialogStub = {
+  name: 'unnnic-dialog',
+  props: {
+    open: { type: Boolean, default: false },
+  },
+  emits: ['update:open'],
+  template: '<div class="unnnic-dialog-stub"><slot /></div>',
+};
+
+const DialogContentStub = {
+  name: 'unnnic-dialog-content',
+  props: {
+    size: { type: String, default: 'medium' },
+  },
+  template: '<div class="unnnic-dialog-content-stub"><slot /></div>',
+};
+
+const DialogHeaderStub = {
+  name: 'unnnic-dialog-header',
+  props: {
+    type: { type: String, default: 'default' },
+  },
+  template: '<div class="unnnic-dialog-header-stub"><slot /></div>',
+};
+
+const DialogTitleStub = {
+  name: 'unnnic-dialog-title',
+  template: '<div class="unnnic-dialog-title-stub"><slot /></div>',
+};
+
+const DialogFooterStub = {
+  name: 'unnnic-dialog-footer',
+  template: '<div class="unnnic-dialog-footer-stub"><slot /></div>',
+};
+
+const ButtonStub = {
+  name: 'unnnic-button',
+  props: {
+    text: { type: String, default: '' },
+    type: { type: String, default: 'primary' },
+    size: { type: String, default: 'large' },
+  },
+  emits: ['click'],
+  template: '<button class="unnnic-button-stub" @click="$emit(\'click\')">{{ text }}</button>',
+};
+
+describe('ConnectNewWhatsAppAccountModal.vue', () => {
+  let wrapper;
+
+  const mountModal = (props = {}) =>
+    mount(ConnectNewWhatsAppAccountModal, {
+      props: {
+        show: true,
+        ...props,
+      },
+      global: {
+        plugins: [i18n],
+        stubs: {
+          'unnnic-dialog': DialogStub,
+          'unnnic-dialog-content': DialogContentStub,
+          'unnnic-dialog-header': DialogHeaderStub,
+          'unnnic-dialog-title': DialogTitleStub,
+          'unnnic-dialog-footer': DialogFooterStub,
+          'unnnic-button': ButtonStub,
+        },
+      },
+    });
+
+  beforeEach(() => {
+    wrapper = mountModal();
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
+  });
+
+  it('renders the dialog with title, description, and try again button', () => {
+    expect(wrapper.find('.connect-new-whatsapp-account-modal').exists()).toBe(true);
+    expect(wrapper.text()).toContain('Connect new WhatsApp account');
+    expect(wrapper.find('.connect-new-whatsapp-account-modal__description').exists()).toBe(true);
+    expect(wrapper.find('.connect-new-whatsapp-account-modal__description').html()).toContain(
+      'Create a <b>new WhatsApp Business Account</b>',
+    );
+
+    const button = wrapper.findComponent({ name: 'unnnic-button' });
+    expect(button.exists()).toBe(true);
+    expect(button.props('text')).toBe('Try again');
+    expect(button.props('type')).toBe('primary');
+  });
+
+  it('binds the show prop to the dialog open state', async () => {
+    const dialog = wrapper.findComponent({ name: 'unnnic-dialog' });
+    expect(dialog.exists()).toBe(true);
+    expect(dialog.props('open')).toBe(true);
+
+    await wrapper.setProps({ show: false });
+    expect(dialog.props('open')).toBe(false);
+  });
+
+  it('defaults show to false', () => {
+    const closedWrapper = mount(ConnectNewWhatsAppAccountModal, {
+      global: {
+        plugins: [i18n],
+        stubs: {
+          'unnnic-dialog': DialogStub,
+          'unnnic-dialog-content': DialogContentStub,
+          'unnnic-dialog-header': DialogHeaderStub,
+          'unnnic-dialog-title': DialogTitleStub,
+          'unnnic-dialog-footer': DialogFooterStub,
+          'unnnic-button': ButtonStub,
+        },
+      },
+    });
+
+    expect(closedWrapper.props('show')).toBe(false);
+    closedWrapper.unmount();
+  });
+
+  it('emits close when the dialog requests to close', async () => {
+    const dialog = wrapper.findComponent({ name: 'unnnic-dialog' });
+
+    await dialog.vm.$emit('update:open', false);
+
+    expect(wrapper.emitted('close')).toBeTruthy();
+    expect(wrapper.emitted('close')).toHaveLength(1);
+    expect(wrapper.emitted('try-again')).toBeFalsy();
+  });
+
+  it('does not emit close when the dialog opens', async () => {
+    await wrapper.setProps({ show: false });
+    const dialog = wrapper.findComponent({ name: 'unnnic-dialog' });
+
+    await dialog.vm.$emit('update:open', true);
+
+    expect(wrapper.emitted('close')).toBeFalsy();
+  });
+
+  it('emits try-again and close when Try again is clicked', async () => {
+    const button = wrapper.findComponent({ name: 'unnnic-button' });
+
+    await button.trigger('click');
+
+    expect(wrapper.emitted('try-again')).toBeTruthy();
+    expect(wrapper.emitted('try-again')).toHaveLength(1);
+    expect(wrapper.emitted('close')).toBeTruthy();
+    expect(wrapper.emitted('close')).toHaveLength(1);
+  });
+
+  it('uses a warning dialog header', () => {
+    const header = wrapper.findComponent({ name: 'unnnic-dialog-header' });
+    expect(header.exists()).toBe(true);
+    expect(header.props('type')).toBe('warning');
+  });
+});

--- a/src/tests/components/config/channels/whatsapp/Setup.spec.js
+++ b/src/tests/components/config/channels/whatsapp/Setup.spec.js
@@ -2,6 +2,7 @@ import { mount } from '@vue/test-utils';
 import { setActivePinia } from 'pinia';
 import { createTestingPinia } from '@pinia/testing';
 import WhatsAppSetup from '@/components/config/channels/whatsapp/Setup.vue';
+import ConnectNewWhatsAppAccountModal from '@/components/config/channels/whatsapp/ConnectNewWhatsAppAccountModal.vue';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import i18n from '@/utils/plugins/i18n';
 import UnnnicSystem from '@/utils/plugins/UnnnicSystem';
@@ -43,6 +44,9 @@ describe('WhatsAppSetup.vue', () => {
     wrapper = mount(WhatsAppSetup, {
       global: {
         plugins: [pinia, i18n, UnnnicSystem],
+        stubs: {
+          ConnectNewWhatsAppAccountModal: true,
+        },
         mocks: {
           $route: { params: { appUuid: '123' } },
           $router: {
@@ -120,6 +124,33 @@ describe('WhatsAppSetup.vue', () => {
     });
 
     await wrapper.vm.createChannel('1234');
+    await wrapper.vm.$nextTick();
+
+    expect(spy).not.toHaveBeenCalled();
+    expect(wrapper.vm.showConnectNewAccountModal).toBe(true);
+
+    const connectModal = wrapper.findComponent(ConnectNewWhatsAppAccountModal);
+    expect(connectModal.exists()).toBe(true);
+    expect(connectModal.props('show')).toBe(true);
+  });
+
+  it('opens ConnectNewWhatsAppAccount modal for nested axios Meta errors', async () => {
+    const spy = vi.spyOn(wrapper.vm, 'callErrorModal');
+    const store = whatsapp_cloud();
+
+    vi.spyOn(wrapper.vm, 'configurePhoneNumber').mockImplementation(async () => {
+      store.errorCloudConfigure = {
+        response: {
+          data: {
+            error: {
+              error_subcode: 1752246,
+            },
+          },
+        },
+      };
+    });
+
+    await wrapper.vm.createChannel('1234');
 
     expect(spy).not.toHaveBeenCalled();
     expect(wrapper.vm.showConnectNewAccountModal).toBe(true);
@@ -128,11 +159,23 @@ describe('WhatsAppSetup.vue', () => {
   it('retries Facebook login from ConnectNewWhatsAppAccount modal', async () => {
     const startSpy = vi.spyOn(wrapper.vm, 'startFacebookLogin').mockImplementation(() => {});
     wrapper.vm.showConnectNewAccountModal = true;
+    await wrapper.vm.$nextTick();
 
-    wrapper.vm.handleConnectNewAccountTryAgain();
+    const connectModal = wrapper.findComponent(ConnectNewWhatsAppAccountModal);
+    await connectModal.vm.$emit('try-again');
 
     expect(wrapper.vm.showConnectNewAccountModal).toBe(false);
     expect(startSpy).toHaveBeenCalled();
+  });
+
+  it('closes ConnectNewWhatsAppAccount modal on close event', async () => {
+    wrapper.vm.showConnectNewAccountModal = true;
+    await wrapper.vm.$nextTick();
+
+    const connectModal = wrapper.findComponent(ConnectNewWhatsAppAccountModal);
+    await connectModal.vm.$emit('close');
+
+    expect(wrapper.vm.showConnectNewAccountModal).toBe(false);
   });
 
   it('reacts to Pinia state changes', async () => {

--- a/src/tests/components/config/channels/whatsapp/Setup.spec.js
+++ b/src/tests/components/config/channels/whatsapp/Setup.spec.js
@@ -91,17 +91,48 @@ describe('WhatsAppSetup.vue', () => {
     expect(wrapper.vm.wabaId).toBeNull();
   });
 
-  it('shows error modal when createChannel fails', async () => {
+  it('shows error toast when createChannel fails with a generic error', async () => {
     const spy = vi.spyOn(wrapper.vm, 'callErrorModal');
+    const store = whatsapp_cloud();
 
-    wrapper.vm.errorCloudConfigure = true;
-    await wrapper.vm.$nextTick();
+    vi.spyOn(wrapper.vm, 'configurePhoneNumber').mockImplementation(async () => {
+      store.errorCloudConfigure = new Error('network');
+    });
 
     await wrapper.vm.createChannel('1234');
 
     expect(spy).toHaveBeenCalledWith({
       text: 'An error occurred while creating the channel. Try again later.',
     });
+    expect(wrapper.vm.showConnectNewAccountModal).toBe(false);
+  });
+
+  it('opens ConnectNewWhatsAppAccount modal on Meta credit allocation error', async () => {
+    const spy = vi.spyOn(wrapper.vm, 'callErrorModal');
+    const store = whatsapp_cloud();
+
+    vi.spyOn(wrapper.vm, 'configurePhoneNumber').mockImplementation(async () => {
+      store.errorCloudConfigure = {
+        message: 'Fatal',
+        type: 'OAuthException',
+        error_subcode: '1752246',
+      };
+    });
+
+    await wrapper.vm.createChannel('1234');
+
+    expect(spy).not.toHaveBeenCalled();
+    expect(wrapper.vm.showConnectNewAccountModal).toBe(true);
+  });
+
+  it('retries Facebook login from ConnectNewWhatsAppAccount modal', async () => {
+    const startSpy = vi.spyOn(wrapper.vm, 'startFacebookLogin').mockImplementation(() => {});
+    wrapper.vm.showConnectNewAccountModal = true;
+
+    wrapper.vm.handleConnectNewAccountTryAgain();
+
+    expect(wrapper.vm.showConnectNewAccountModal).toBe(false);
+    expect(startSpy).toHaveBeenCalled();
   });
 
   it('reacts to Pinia state changes', async () => {

--- a/src/tests/utils/metaError.spec.js
+++ b/src/tests/utils/metaError.spec.js
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { isMetaCreditAllocationError, META_CREDIT_ALLOCATION_SUBCODE } from '@/utils/metaError';
+
+const metaPayload = {
+  error: {
+    message: 'Fatal',
+    type: 'OAuthException',
+    code: '-1',
+    error_subcode: META_CREDIT_ALLOCATION_SUBCODE,
+    is_transient: 'False',
+    error_user_title: 'Alocação de crédito não permitida',
+    error_user_msg: 'A moeda fornecida para o objeto faturável não será aceita.',
+    fbtrace_id: 'ANVS9Va2_vOb2vAsaX3X0HW',
+  },
+};
+
+describe('isMetaCreditAllocationError', () => {
+  it('returns true for the Meta credit allocation payload', () => {
+    expect(isMetaCreditAllocationError(metaPayload)).toBe(true);
+  });
+
+  it('returns true when error_subcode is a number', () => {
+    expect(
+      isMetaCreditAllocationError({
+        error: { error_subcode: 1752246 },
+      }),
+    ).toBe(true);
+  });
+
+  it('returns true for the store-captured Meta error object', () => {
+    expect(isMetaCreditAllocationError(metaPayload.error)).toBe(true);
+  });
+
+  it('returns true for axios-style errors', () => {
+    expect(
+      isMetaCreditAllocationError({
+        response: { data: metaPayload },
+      }),
+    ).toBe(true);
+  });
+
+  it('returns true for stringified JSON', () => {
+    expect(isMetaCreditAllocationError(JSON.stringify(metaPayload))).toBe(true);
+  });
+
+  it('returns false for unrelated errors', () => {
+    expect(isMetaCreditAllocationError({ error: { message: 'boom' } })).toBe(false);
+    expect(isMetaCreditAllocationError(new Error('network'))).toBe(false);
+    expect(isMetaCreditAllocationError(null)).toBe(false);
+    expect(isMetaCreditAllocationError(true)).toBe(false);
+  });
+
+  it('returns false for a different error_subcode', () => {
+    expect(
+      isMetaCreditAllocationError({
+        error: { error_subcode: '9999999' },
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/tests/utils/metaError.spec.js
+++ b/src/tests/utils/metaError.spec.js
@@ -57,4 +57,38 @@ describe('isMetaCreditAllocationError', () => {
       }),
     ).toBe(false);
   });
+
+  it('returns true when the subcode is nested inside an array', () => {
+    expect(
+      isMetaCreditAllocationError({
+        errors: [{ code: 1 }, { error_subcode: META_CREDIT_ALLOCATION_SUBCODE }],
+      }),
+    ).toBe(true);
+  });
+
+  it('returns true when a plain string contains the subcode', () => {
+    expect(
+      isMetaCreditAllocationError(`Meta failed with subcode ${META_CREDIT_ALLOCATION_SUBCODE}`),
+    ).toBe(true);
+  });
+
+  it('returns false for circular object graphs without the subcode', () => {
+    const circular = { error: { message: 'boom' } };
+    circular.self = circular;
+
+    expect(isMetaCreditAllocationError(circular)).toBe(false);
+  });
+
+  it('returns true for circular object graphs that include the subcode', () => {
+    const circular = {
+      error: { error_subcode: META_CREDIT_ALLOCATION_SUBCODE },
+    };
+    circular.self = circular;
+
+    expect(isMetaCreditAllocationError(circular)).toBe(true);
+  });
+
+  it('exports the expected Meta credit allocation subcode', () => {
+    expect(META_CREDIT_ALLOCATION_SUBCODE).toBe('1752246');
+  });
 });

--- a/src/utils/metaError.js
+++ b/src/utils/metaError.js
@@ -1,0 +1,53 @@
+export const META_CREDIT_ALLOCATION_SUBCODE = '1752246';
+
+function matchesSubcode(value, subcode) {
+  if (typeof value === 'number') {
+    return String(value) === subcode;
+  }
+  if (typeof value === 'string') {
+    return value === subcode;
+  }
+  return false;
+}
+
+function hasMetaErrorSubcode(value, subcode, seen = new WeakSet()) {
+  if (value == null) {
+    return false;
+  }
+
+  if (typeof value === 'string') {
+    try {
+      return hasMetaErrorSubcode(JSON.parse(value), subcode, seen);
+    } catch {
+      return value.includes(subcode);
+    }
+  }
+
+  if (typeof value !== 'object') {
+    return false;
+  }
+
+  if (seen.has(value)) {
+    return false;
+  }
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    return value.some((item) => hasMetaErrorSubcode(item, subcode, seen));
+  }
+
+  if ('error_subcode' in value && matchesSubcode(value.error_subcode, subcode)) {
+    return true;
+  }
+
+  // Axios-style errors carry the payload under response.data
+  if (value.response?.data != null) {
+    return hasMetaErrorSubcode(value.response.data, subcode, seen);
+  }
+
+  return Object.values(value).some((nested) => hasMetaErrorSubcode(nested, subcode, seen));
+}
+
+export function isMetaCreditAllocationError(value) {
+  return hasMetaErrorSubcode(value, META_CREDIT_ALLOCATION_SUBCODE);
+}


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bug fix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When Meta returns `error_subcode` `1752246` during WhatsApp Cloud channel creation (credit allocation not allowed for the selected WABA), users only saw a generic error toast and had no clear next step. This change guides them to create a new WhatsApp Business Account and retry the Embedded Signup flow.

### Summary of Changes
<!--- Describe your changes in detail -->
- Add `isMetaCreditAllocationError` helper to detect Meta `error_subcode` `1752246` in nested/axios error payloads
- Add `ConnectNewWhatsAppAccountModal` (Unnnic) with localized copy (EN, pt-BR, es, ro), including HTML formatting (`<br />`, `<b>`, `<ol>`)
- In WhatsApp Cloud `Setup.vue`, when `configurePhoneNumber` fails with this subcode, open the guidance modal instead of the generic toast
- **Try again** closes the modal and restarts Facebook Embedded Signup
- Add unit tests for the Meta error helper and Setup failure/retry behavior

### Demonstration <!--- (If not appropriate, remove this topic) -->

<img width="573" height="492" alt="image" src="https://github.com/user-attachments/assets/73fb2cc0-324f-4a0f-8701-21aa9c26fbd5" />