### PR TITLE
✨ BRL billing migration disclaimer on WhatsApp General tab

### DIFF
--- a/src/components/config/channels/whatsapp/components/tabs/AccountTab.vue
+++ b/src/components/config/channels/whatsapp/components/tabs/AccountTab.vue
@@ -1,6 +1,13 @@
 <template>
   <div class="account-tab">
     <div class="account-tab__content">
+      <unnnic-disclaimer
+        class="account-tab__content__brl-disclaimer"
+        type="informational"
+        :title="$t('WhatsApp.config.billing.brl_disclaimer.title')"
+        :description="$t('WhatsApp.config.billing.brl_disclaimer.description')"
+      />
+
       <section
         v-if="isProjectWithVoiceCalling"
         :class="[
@@ -522,6 +529,11 @@
       margin-top: $unnnic-spacing-stack-sm;
       overflow-x: hidden;
       flex: 1;
+
+      &__brl-disclaimer {
+        min-height: auto;
+        margin-bottom: $unnnic-spacing-stack-md;
+      }
 
       &__info {
         display: flex;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -398,6 +398,10 @@
         }
       },
       "billing": {
+        "brl_disclaimer": {
+          "description": "Meta now charges WhatsApp messages in Reais in Brazil. On July 30, 2026, the account was updated automatically: a new WhatsApp Business account (WABA) in Reais was created, and the number, templates, and flows were moved to it. Service kept running normally and no action is needed.",
+          "title": "Account now billed in Brazilian Reais (BRL)"
+        },
         "title": "Payment information"
       },
       "account_verification": {

--- a/src/locales/es_es.json
+++ b/src/locales/es_es.json
@@ -398,6 +398,10 @@
         }
       },
       "billing": {
+        "brl_disclaimer": {
+          "description": "Meta ahora cobra mensajes de WhatsApp en reales en Brasil. El 30 de julio de 2026, la cuenta se actualizó automáticamente: se creó una nueva cuenta de persona jurídica de WhatsApp (WABA) en reales, y el número, plantillas y flujos se transfirieron a ella. El servicio continuó funcionando normalmente y no se requiere ninguna acción.",
+          "title": "Cuenta ahora facturada en reales brasileños (BRL)"
+        },
         "title": "Información de pago"
       },
       "account_verification": {

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -398,6 +398,10 @@
         }
       },
       "billing": {
+        "brl_disclaimer": {
+          "description": "A Meta agora cobra mensagens do WhatsApp em reais no Brasil. Em 30 de julho de 2026, a conta foi atualizada automaticamente: uma nova conta de pessoa jurídica do WhatsApp (WABA) em reais foi criada, e o número, templates e fluxos foram transferidos para ela. O serviço continuou funcionando normalmente e nenhuma ação é necessária.",
+          "title": "Conta agora cobrada em reais (BRL)"
+        },
         "title": "Informações de pagamento"
       },
       "account_verification": {

--- a/src/locales/ro_ro.json
+++ b/src/locales/ro_ro.json
@@ -398,6 +398,10 @@
         }
       },
       "billing": {
+        "brl_disclaimer": {
+          "description": "Meta acum taxează mesajele WhatsApp în reali în Brazilia. Pe 30 iulie 2026, contul a fost actualizat automat: un cont WhatsApp Business nou (WABA) în reali a fost creat, iar numărul, șabloanele și fluxurile au fost mutate în el. Serviciul a continuat să funcționeze normal și nu este necesară nicio acțiune.",
+          "title": "Cont facturat acum în reali brazilieni (BRL)"
+        },
         "title": "Informații de plată"
       },
       "account_verification": {


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
Meta now bills WhatsApp messages in Brazilian Reais (BRL) in Brazil. On July 30, 2026, affected accounts were migrated automatically to a new WABA in BRL. Users need clear in-product context about this change and that no action is required.

### Summary of Changes
- Added an informational `unnnic-disclaimer` at the top of the WhatsApp General tab (`AccountTab`)
- Added i18n keys under `WhatsApp.config.billing.brl_disclaimer` in EN, pt-BR, ES, and RO

### Design Files
- [Atualizações Integrations WhatsApp](https://www.figma.com/design/4CMZ92v3aOpEbDKJHyoSJW/Atualiza%C3%A7%C3%B5es-Integrations-WhatsApp?node-id=2008-1159&m=dev)

### Demonstration

<img width="847" height="119" alt="image" src="https://github.com/user-attachments/assets/df33ff77-ecdd-4c5c-ab34-6424e2997d66" />